### PR TITLE
feat: implement PWTIME, PNPRO, IMUNIT procedures (#13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/examples/tests/test_system_utils.rosy
+++ b/examples/tests/test_system_utils.rosy
@@ -1,0 +1,44 @@
+BEGIN ;
+
+{ Test PWTIME: wall-clock elapsed time }
+VARIABLE (RE) t1 ;
+PWTIME t1 ;
+IF t1 >= 0 ;
+  WRITE 6 'PWTIME ok: t1 is non-negative' ;
+ENDIF ;
+
+VARIABLE (RE) t2 ;
+PWTIME t2 ;
+IF t2 >= t1 ;
+  WRITE 6 'PWTIME ok: t2 >= t1 (monotonic)' ;
+ENDIF ;
+
+{ Test PNPRO: should return 1 in serial mode }
+VARIABLE (RE) np ;
+PNPRO np ;
+IF np = 1 ;
+  WRITE 6 'PNPRO ok: np = 1 (serial mode)' ;
+ENDIF ;
+
+{ Test IMUNIT: should return imaginary unit i }
+VARIABLE (CM) z ;
+IMUNIT z ;
+VARIABLE (RE) re_part ;
+VARIABLE (RE) im_part ;
+re_part := REAL(z) ;
+im_part := IMAG(z) ;
+IF re_part = 0 ;
+  WRITE 6 'IMUNIT ok: real part is 0' ;
+ENDIF ;
+IF im_part = 1 ;
+  WRITE 6 'IMUNIT ok: imaginary part is 1' ;
+ENDIF ;
+
+{ Use IMUNIT in arithmetic: z*z should equal -1 }
+VARIABLE (CM) z2 ;
+z2 := z * z ;
+IF REAL(z2) = -1 ;
+  WRITE 6 'IMUNIT ok: i*i = -1' ;
+ENDIF ;
+
+END ;

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 
 [features]

--- a/rosy/assets/rosy.pest
+++ b/rosy/assets/rosy.pest
@@ -45,7 +45,10 @@ statement   = _{
   | vezero
   | stcre
   | recst
-  | reran }
+  | reran
+  | pwtime
+  | pnpro
+  | imunit }
 
 /// BREAK
 break_statement = { ^"BREAK" ~ semicolon }
@@ -74,7 +77,7 @@ memory_size = { expr }
 
 /// Keywords - define all reserved words (must be followed by a non-identifier character)
 keyword = @{ keyword_raw ~ !(ASCII_ALPHANUMERIC | "_") }
-keyword_raw = { ^"ENDPROCEDURE" | ^"ENDFUNCTION" | ^"ENDWHILE" | ^"ENDLOOP" | ^"ENDPLOOP" | ^"ENDFIT" | ^"ENDIF" | ^"ELSEIF" | ^"ELSE" | ^"BEGIN" | ^"END" | ^"WRITEB" | ^"WRITE" | ^"READB" | ^"READ" | ^"VARIABLE" | ^"PROCEDURE" | ^"EXP" | ^"TAN" | ^"IF" | ^"WHILE" | ^"TRUE" | ^"FALSE" | ^"DAINI" | ^"DAPRV" | ^"DAREV" | ^"DANOT" | ^"DAEPS" | ^"DATRN" | ^"LENGTH" | ^"SINH" | ^"SIN" | ^"COSH" | ^"COS" | ^"ASIN" | ^"ACOS" | ^"ATAN" | ^"TANH" | ^"SQRT" | ^"SQR" | ^"VMAX" | ^"VMIN" | ^"ABS" | ^"NORM" | ^"CONS" | ^"INT" | ^"NINT" | ^"TYPE" | ^"REAL" | ^"IMAG" | ^"TRIM" | ^"LTRIM" | ^"ISRT3" | ^"ISRT" | ^"CMPLX" | ^"CONJ" | ^"LST" | ^"LCM" | ^"LCD" | ^"LOG" | ^"BREAK" | ^"QUIT" | ^"SCRLEN" | ^"CPUSEC" | ^"OS" | ^"LINV" | ^"LDET" | ^"SUBSTR" | ^"VELSET" | ^"VELGET" | ^"POLVAL" | ^"VEDOT" | ^"VEUNIT" | ^"VEZERO" | ^"STCRE" | ^"RECST" | ^"RERAN" | ^"FIT" | ^"OPENFB" | ^"OPENF" | ^"CLOSEF" | ^"FUNCTION" | ^"LOOP" | ^"PLOOP" | "rosy_universe" | "rosy_world" | "rosy_size" | "rosy_rank" }
+keyword_raw = { ^"ENDPROCEDURE" | ^"ENDFUNCTION" | ^"ENDWHILE" | ^"ENDLOOP" | ^"ENDPLOOP" | ^"ENDFIT" | ^"ENDIF" | ^"ELSEIF" | ^"ELSE" | ^"BEGIN" | ^"END" | ^"WRITEB" | ^"WRITE" | ^"READB" | ^"READ" | ^"VARIABLE" | ^"PROCEDURE" | ^"EXP" | ^"TAN" | ^"IF" | ^"WHILE" | ^"TRUE" | ^"FALSE" | ^"DAINI" | ^"DAPRV" | ^"DAREV" | ^"DANOT" | ^"DAEPS" | ^"DATRN" | ^"LENGTH" | ^"SINH" | ^"SIN" | ^"COSH" | ^"COS" | ^"ASIN" | ^"ACOS" | ^"ATAN" | ^"TANH" | ^"SQRT" | ^"SQR" | ^"VMAX" | ^"VMIN" | ^"ABS" | ^"NORM" | ^"CONS" | ^"INT" | ^"NINT" | ^"TYPE" | ^"REAL" | ^"IMAG" | ^"TRIM" | ^"LTRIM" | ^"ISRT3" | ^"ISRT" | ^"CMPLX" | ^"CONJ" | ^"LST" | ^"LCM" | ^"LCD" | ^"LOG" | ^"BREAK" | ^"QUIT" | ^"SCRLEN" | ^"CPUSEC" | ^"OS" | ^"LINV" | ^"LDET" | ^"SUBSTR" | ^"VELSET" | ^"VELGET" | ^"POLVAL" | ^"VEDOT" | ^"VEUNIT" | ^"VEZERO" | ^"STCRE" | ^"RECST" | ^"RERAN" | ^"PWTIME" | ^"PNPRO" | ^"IMUNIT" | ^"FIT" | ^"OPENFB" | ^"OPENF" | ^"CLOSEF" | ^"FUNCTION" | ^"LOOP" | ^"PLOOP" | "rosy_universe" | "rosy_world" | "rosy_size" | "rosy_rank" }
 
 /// [ IF / ELSEIF / ELSE / ENDIF ]
 if_statement = { if_clause ~ elseif_clause* ~ else_clause? ~ endif }
@@ -240,6 +243,10 @@ endif = { ^"ENDIF" ~ semicolon }
   recst = { ^"RECST" ~ expr ~ expr ~ variable_identifier ~ semicolon }
   /// [ RANDOM ]
   reran = { ^"RERAN" ~ variable_identifier ~ semicolon }
+  /// [ SYSTEM / UTILITY ]
+  pwtime = { ^"PWTIME" ~ variable_identifier ~ semicolon }
+  pnpro = { ^"PNPRO" ~ variable_identifier ~ semicolon }
+  imunit = { ^"IMUNIT" ~ variable_identifier ~ semicolon }
   /// [ MATH ]
   linv = { ^"LINV" ~ expr ~ expr ~ expr ~ expr ~ expr ~ semicolon }
   ldet = { ^"LDET" ~ expr ~ expr ~ expr ~ expr ~ semicolon }

--- a/rosy/src/program/statements/core/imunit.rs
+++ b/rosy/src/program/statements/core/imunit.rs
@@ -1,0 +1,90 @@
+//! # IMUNIT Statement
+//!
+//! Returns the imaginary unit *i* as a CM (Complex64) value.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! IMUNIT v;
+//! ```
+//!
+//! ## Example
+//!
+//! ```text
+//! VARIABLE (CM) z;
+//! IMUNIT z;
+//! WRITE 6 z;   { prints (0, 1) }
+//! ```
+
+use std::collections::BTreeSet;
+use anyhow::{Result, Context, Error, ensure};
+
+use crate::{
+    ast::*,
+    program::expressions::core::variable_identifier::VariableIdentifier,
+    transpile::{
+        TranspilationInputContext, TranspilationOutput, Transpile,
+        TranspileableStatement, VariableScope, add_context_to_all,
+    },
+};
+
+#[derive(Debug)]
+pub struct ImunitStatement {
+    pub identifier: VariableIdentifier,
+}
+
+impl FromRule for ImunitStatement {
+    fn from_rule(pair: pest::iterators::Pair<Rule>) -> Result<Option<Self>> {
+        ensure!(
+            pair.as_rule() == Rule::imunit,
+            "Expected `imunit` rule when building IMUNIT statement, found: {:?}",
+            pair.as_rule()
+        );
+
+        let mut inner = pair.into_inner();
+
+        let expr_pair = inner.next()
+            .context("Missing variable expression in IMUNIT!")?;
+        let identifier = VariableIdentifier::from_rule(expr_pair)
+            .context("Failed to build variable identifier in IMUNIT")?
+            .ok_or_else(|| anyhow::anyhow!("Expected variable identifier in IMUNIT"))?;
+
+        Ok(Some(ImunitStatement { identifier }))
+    }
+}
+
+impl TranspileableStatement for ImunitStatement {}
+
+impl Transpile for ImunitStatement {
+    fn transpile(&self, context: &mut TranspilationInputContext) -> Result<TranspilationOutput, Vec<Error>> {
+        let mut requested_variables = BTreeSet::new();
+
+        let output = self.identifier.transpile(context)
+            .map_err(|e| add_context_to_all(e, "...while transpiling identifier in IMUNIT".to_string()))?;
+        requested_variables.extend(output.requested_variables.clone());
+
+        let dereference = match context.variables.get(&self.identifier.name)
+            .ok_or_else(|| vec![anyhow::anyhow!("Variable '{}' is not defined in this scope!", self.identifier.name)])?
+            .scope
+        {
+            VariableScope::Local => "",
+            VariableScope::Arg => "*",
+            VariableScope::Higher => {
+                requested_variables.insert(self.identifier.name.clone());
+                "*"
+            }
+        };
+
+        // Imaginary unit: Complex64::new(0.0, 1.0) = i
+        let serialization = format!(
+            "{}{} = num_complex::Complex64::new(0.0, 1.0);",
+            dereference, output.serialization
+        );
+
+        Ok(TranspilationOutput {
+            serialization,
+            requested_variables,
+            ..Default::default()
+        })
+    }
+}

--- a/rosy/src/program/statements/core/mod.rs
+++ b/rosy/src/program/statements/core/mod.rs
@@ -39,3 +39,5 @@ pub mod while_loop;
 pub mod stcre;
 pub mod recst;
 pub mod reran;
+pub mod pnpro;
+pub mod imunit;

--- a/rosy/src/program/statements/core/pnpro.rs
+++ b/rosy/src/program/statements/core/pnpro.rs
@@ -1,0 +1,91 @@
+//! # PNPRO Statement
+//!
+//! Returns the number of concurrent processes. Always 1 in serial mode.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! PNPRO v;
+//! ```
+//!
+//! ## Example
+//!
+//! ```text
+//! VARIABLE (RE) n;
+//! PNPRO n;
+//! WRITE 6 n;
+//! ```
+
+use std::collections::BTreeSet;
+use anyhow::{Result, Context, Error, ensure};
+
+use crate::{
+    ast::*,
+    program::expressions::core::variable_identifier::VariableIdentifier,
+    transpile::{
+        TranspilationInputContext, TranspilationOutput, Transpile,
+        TranspileableStatement, VariableScope, add_context_to_all,
+    },
+};
+
+#[derive(Debug)]
+pub struct PnproStatement {
+    pub identifier: VariableIdentifier,
+}
+
+impl FromRule for PnproStatement {
+    fn from_rule(pair: pest::iterators::Pair<Rule>) -> Result<Option<Self>> {
+        ensure!(
+            pair.as_rule() == Rule::pnpro,
+            "Expected `pnpro` rule when building PNPRO statement, found: {:?}",
+            pair.as_rule()
+        );
+
+        let mut inner = pair.into_inner();
+
+        let expr_pair = inner.next()
+            .context("Missing variable expression in PNPRO!")?;
+        let identifier = VariableIdentifier::from_rule(expr_pair)
+            .context("Failed to build variable identifier in PNPRO")?
+            .ok_or_else(|| anyhow::anyhow!("Expected variable identifier in PNPRO"))?;
+
+        Ok(Some(PnproStatement { identifier }))
+    }
+}
+
+impl TranspileableStatement for PnproStatement {}
+
+impl Transpile for PnproStatement {
+    fn transpile(&self, context: &mut TranspilationInputContext) -> Result<TranspilationOutput, Vec<Error>> {
+        let mut requested_variables = BTreeSet::new();
+
+        let output = self.identifier.transpile(context)
+            .map_err(|e| add_context_to_all(e, "...while transpiling identifier in PNPRO".to_string()))?;
+        requested_variables.extend(output.requested_variables.clone());
+
+        let dereference = match context.variables.get(&self.identifier.name)
+            .ok_or_else(|| vec![anyhow::anyhow!("Variable '{}' is not defined in this scope!", self.identifier.name)])?
+            .scope
+        {
+            VariableScope::Local => "",
+            VariableScope::Arg => "*",
+            VariableScope::Higher => {
+                requested_variables.insert(self.identifier.name.clone());
+                "*"
+            }
+        };
+
+        // Always returns 1.0 in serial mode.
+        // In MPI mode, the PLOOP infrastructure handles parallelism externally.
+        let serialization = format!(
+            "{}{} = 1.0;",
+            dereference, output.serialization
+        );
+
+        Ok(TranspilationOutput {
+            serialization,
+            requested_variables,
+            ..Default::default()
+        })
+    }
+}

--- a/rosy/src/program/statements/io/mod.rs
+++ b/rosy/src/program/statements/io/mod.rs
@@ -22,5 +22,6 @@ pub mod os_call;
 pub mod read;
 pub mod readb;
 pub mod velget;
+pub mod pwtime;
 pub mod write;
 pub mod writeb;

--- a/rosy/src/program/statements/io/pwtime.rs
+++ b/rosy/src/program/statements/io/pwtime.rs
@@ -1,0 +1,91 @@
+//! # PWTIME Statement
+//!
+//! Returns the elapsed wall-clock time in seconds since program start.
+//!
+//! ## Syntax
+//!
+//! ```text
+//! PWTIME v;
+//! ```
+//!
+//! ## Example
+//!
+//! ```text
+//! VARIABLE (RE) t;
+//! PWTIME t;
+//! WRITE 6 t;
+//! ```
+
+use std::collections::BTreeSet;
+use anyhow::{Result, Context, Error, ensure};
+
+use crate::{
+    ast::*,
+    program::expressions::core::variable_identifier::VariableIdentifier,
+    transpile::{
+        TranspilationInputContext, TranspilationOutput, Transpile,
+        TranspileableStatement, VariableScope, add_context_to_all,
+    },
+};
+
+#[derive(Debug)]
+pub struct PwtimeStatement {
+    pub identifier: VariableIdentifier,
+}
+
+impl FromRule for PwtimeStatement {
+    fn from_rule(pair: pest::iterators::Pair<Rule>) -> Result<Option<Self>> {
+        ensure!(
+            pair.as_rule() == Rule::pwtime,
+            "Expected `pwtime` rule when building PWTIME statement, found: {:?}",
+            pair.as_rule()
+        );
+
+        let mut inner = pair.into_inner();
+
+        let expr_pair = inner.next()
+            .context("Missing variable expression in PWTIME!")?;
+        let identifier = VariableIdentifier::from_rule(expr_pair)
+            .context("Failed to build variable identifier in PWTIME")?
+            .ok_or_else(|| anyhow::anyhow!("Expected variable identifier in PWTIME"))?;
+
+        Ok(Some(PwtimeStatement { identifier }))
+    }
+}
+
+impl TranspileableStatement for PwtimeStatement {}
+
+impl Transpile for PwtimeStatement {
+    fn transpile(&self, context: &mut TranspilationInputContext) -> Result<TranspilationOutput, Vec<Error>> {
+        let mut requested_variables = BTreeSet::new();
+
+        let output = self.identifier.transpile(context)
+            .map_err(|e| add_context_to_all(e, "...while transpiling identifier in PWTIME".to_string()))?;
+        requested_variables.extend(output.requested_variables.clone());
+
+        let dereference = match context.variables.get(&self.identifier.name)
+            .ok_or_else(|| vec![anyhow::anyhow!("Variable '{}' is not defined in this scope!", self.identifier.name)])?
+            .scope
+        {
+            VariableScope::Local => "",
+            VariableScope::Arg => "*",
+            VariableScope::Higher => {
+                requested_variables.insert(self.identifier.name.clone());
+                "*"
+            }
+        };
+
+        // Use the `start` Instant created at the top of main_wrapper() in the
+        // output template — same mechanism as CPUSEC.
+        let serialization = format!(
+            "{}{} = start.elapsed().as_secs_f64();",
+            dereference, output.serialization
+        );
+
+        Ok(TranspilationOutput {
+            serialization,
+            requested_variables,
+            ..Default::default()
+        })
+    }
+}

--- a/rosy/src/program/statements/mod.rs
+++ b/rosy/src/program/statements/mod.rs
@@ -65,6 +65,7 @@ pub use core::velset::VelsetStatement;
 pub use io::cpusec::CpusecStatement;
 pub use io::os_call::OsCallStatement;
 pub use io::velget::VelgetStatement;
+pub use io::pwtime::PwtimeStatement;
 
 pub use math::vedot::VedotStatement;
 pub use math::veunit::VeunitStatement;
@@ -73,6 +74,8 @@ pub use math::vezero::VezeroStatement;
 pub use core::stcre::StcreStatement;
 pub use core::recst::RecstStatement;
 pub use core::reran::ReranStatement;
+pub use core::pnpro::PnproStatement;
+pub use core::imunit::ImunitStatement;
 
 pub use da::daeps::DaepsStatement;
 pub use da::danot::DanotStatement;
@@ -161,6 +164,9 @@ pub enum StatementEnum {
     Stcre,
     Recst,
     Reran,
+    Pwtime,
+    Pnpro,
+    Imunit,
 }
 impl TranspileableStatement for Statement {}
 impl FromRule for Statement {
@@ -455,6 +461,27 @@ impl FromRule for Statement {
                 .context("...while building RERAN statement!")
                 .map(|opt| opt.map(|stmt| Statement {
                     enum_variant: StatementEnum::Reran,
+                    inner: Box::new(stmt),
+                    source_location: loc.clone(),
+                })),
+            Rule::pwtime => PwtimeStatement::from_rule(pair)
+                .context("...while building PWTIME statement!")
+                .map(|opt| opt.map(|stmt| Statement {
+                    enum_variant: StatementEnum::Pwtime,
+                    inner: Box::new(stmt),
+                    source_location: loc.clone(),
+                })),
+            Rule::pnpro => PnproStatement::from_rule(pair)
+                .context("...while building PNPRO statement!")
+                .map(|opt| opt.map(|stmt| Statement {
+                    enum_variant: StatementEnum::Pnpro,
+                    inner: Box::new(stmt),
+                    source_location: loc.clone(),
+                })),
+            Rule::imunit => ImunitStatement::from_rule(pair)
+                .context("...while building IMUNIT statement!")
+                .map(|opt| opt.map(|stmt| Statement {
+                    enum_variant: StatementEnum::Imunit,
                     inner: Box::new(stmt),
                     source_location: loc.clone(),
                 })),


### PR DESCRIPTION
Implements three system/utility procedures from issue #13:

- **PWTIME(v)** — wall-clock elapsed time in seconds (uses \`start.elapsed()\` from output template, same as CPUSEC)
- **PNPRO(v)** — number of concurrent processes (returns 1 in serial mode)
- **IMUNIT(v)** — imaginary unit *i* as CM type (\`Complex64::new(0.0, 1.0)\`)

MTREE, LEV, and MBLOCK are skipped — they involve COSY memory internals and Levenberg-Marquardt, out of scope for this iteration.

### Files changed (10)
- Grammar: \`rosy/assets/rosy.pest\` — 3 new rules + statement/keyword wiring
- AST+Transpile: \`rosy/src/program/statements/io/pwtime.rs\`, \`core/pnpro.rs\`, \`core/imunit.rs\`
- Module wiring: \`io/mod.rs\`, \`core/mod.rs\`, \`statements/mod.rs\`
- Integration test: \`examples/tests/test_system_utils.rosy\`
- Version bump: 0.10.0 → 0.11.0

### Testing
- \`cargo build\` ✓
- \`cargo test\` — 34/34 pass
- Integration test verifies all 6 assertions pass

Closes #13