### PR TITLE
refactor: remove ExprEnum, StatementEnum, make ConcatExpr binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "0.33.0"
+version = "0.33.1"
 edition = "2024"
 
 [lib]

--- a/rosy/src/program/expressions/core/var_expr/mod.rs
+++ b/rosy/src/program/expressions/core/var_expr/mod.rs
@@ -46,7 +46,7 @@ use super::variable_identifier::VariableIdentifier;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{
     TranspilationInputContext, TranspilationOutput, Transpile, ValueKind, VariableScope,
 };
@@ -66,7 +66,7 @@ pub enum VarExprKind {
     FunctionCall,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VarExpr {
     pub identifier: VariableIdentifier,
 }
@@ -303,9 +303,6 @@ impl TranspileableExpr for VarExpr {
         } else {
             ExprRecipe::Unknown
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for VarExpr {

--- a/rosy/src/program/expressions/core/variable_identifier/mod.rs
+++ b/rosy/src/program/expressions/core/variable_identifier/mod.rs
@@ -44,7 +44,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::HashSet;
 
 /// A parsed identifier with optional parenthesized arguments and bracket indices.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VariableIdentifier {
     pub name: String,
     /// Each paren group `(expr, ...)` is a `Vec<Expr>`.
@@ -189,9 +189,6 @@ impl TranspileableExpr for VariableIdentifier {
         } else {
             ExprRecipe::Unknown
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 

--- a/rosy/src/program/expressions/functions/conversion/complex_convert/mod.rs
+++ b/rosy/src/program/expressions/functions/conversion/complex_convert/mod.rs
@@ -30,13 +30,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Context, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `CM(expr)` type conversion function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ComplexConvertExpr {
     pub expr: Box<Expr>,
 }
@@ -84,9 +84,6 @@ impl TranspileableExpr for ComplexConvertExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::CM())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for ComplexConvertExpr {

--- a/rosy/src/program/expressions/functions/conversion/logical_convert/mod.rs
+++ b/rosy/src/program/expressions/functions/conversion/logical_convert/mod.rs
@@ -29,13 +29,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Context, Error, Result, anyhow};
 use std::collections::HashSet;
 
 /// AST node for the `LO(expr)` type conversion function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LogicalConvertExpr {
     pub expr: Box<Expr>,
 }
@@ -80,9 +80,6 @@ impl TranspileableExpr for LogicalConvertExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for LogicalConvertExpr {

--- a/rosy/src/program/expressions/functions/conversion/re_convert/mod.rs
+++ b/rosy/src/program/expressions/functions/conversion/re_convert/mod.rs
@@ -39,13 +39,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Context, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `RE(expr)` type conversion function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ReConvertExpr {
     pub expr: Box<Expr>,
 }
@@ -96,9 +96,6 @@ impl TranspileableExpr for ReConvertExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 

--- a/rosy/src/program/expressions/functions/conversion/string_convert/mod.rs
+++ b/rosy/src/program/expressions/functions/conversion/string_convert/mod.rs
@@ -33,13 +33,13 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context, Error, Result, anyhow};
 
 /// AST node for the `ST(expr)` type conversion function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct StringConvertExpr {
     pub expr: Box<Expr>,
 }
@@ -85,9 +85,6 @@ impl TranspileableExpr for StringConvertExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::ST())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for StringConvertExpr {

--- a/rosy/src/program/expressions/functions/conversion/ve_convert/mod.rs
+++ b/rosy/src/program/expressions/functions/conversion/ve_convert/mod.rs
@@ -37,13 +37,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Context, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `VE(expr)` type conversion function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VeConvertExpr {
     pub expr: Box<Expr>,
 }
@@ -94,9 +94,6 @@ impl TranspileableExpr for VeConvertExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::VE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 

--- a/rosy/src/program/expressions/functions/math/complex/cmplx/mod.rs
+++ b/rosy/src/program/expressions/functions/math/complex/cmplx/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `CMPLX(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct CmplxExpr {
     pub expr: Box<Expr>,
 }
@@ -116,8 +116,5 @@ impl TranspileableExpr for CmplxExpr {
         // CMPLX has non-uniform output types (RE/CM->CM, DA/CD->CD).
         // Defer to type_of() which calls get_return_type().
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/complex/conj/mod.rs
+++ b/rosy/src/program/expressions/functions/math/complex/conj/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `CONJ(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ConjExpr {
     pub expr: Box<Expr>,
 }
@@ -113,8 +113,5 @@ impl TranspileableExpr for ConjExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/complex/imag_fn/mod.rs
+++ b/rosy/src/program/expressions/functions/math/complex/imag_fn/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `IMAG(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ImagFnExpr {
     pub expr: Box<Expr>,
 }
@@ -118,8 +118,5 @@ impl TranspileableExpr for ImagFnExpr {
     ) -> ExprRecipe {
         let inner = resolver.build_expr_recipe(&self.expr, ctx, deps);
         ExprRecipe::ImagFn(Box::new(inner))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/complex/real_fn/mod.rs
+++ b/rosy/src/program/expressions/functions/math/complex/real_fn/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `REAL(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct RealFnExpr {
     pub expr: Box<Expr>,
 }
@@ -118,8 +118,5 @@ impl TranspileableExpr for RealFnExpr {
     ) -> ExprRecipe {
         let inner = resolver.build_expr_recipe(&self.expr, ctx, deps);
         ExprRecipe::RealFn(Box::new(inner))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/exponential/exp/mod.rs
+++ b/rosy/src/program/expressions/functions/math/exponential/exp/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `EXP(expr)` intrinsic function (exponential e^x).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ExpExpr {
     pub expr: Box<Expr>,
 }
@@ -122,8 +122,5 @@ impl TranspileableExpr for ExpExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/exponential/log/mod.rs
+++ b/rosy/src/program/expressions/functions/math/exponential/log/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `LOG(expr)` intrinsic function (natural logarithm ln(x)).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LogExpr {
     pub expr: Box<Expr>,
 }
@@ -122,8 +122,5 @@ impl TranspileableExpr for LogExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/exponential/pow/mod.rs
+++ b/rosy/src/program/expressions/functions/math/exponential/pow/mod.rs
@@ -38,12 +38,12 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the power/exponentiation operator (`^`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct PowExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -92,9 +92,6 @@ impl TranspileableExpr for PowExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for PowExpr {

--- a/rosy/src/program/expressions/functions/math/exponential/sqr/mod.rs
+++ b/rosy/src/program/expressions/functions/math/exponential/sqr/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `SQR(expr)` intrinsic function (square root).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct SqrExpr {
     pub expr: Box<Expr>,
 }
@@ -124,8 +124,5 @@ impl TranspileableExpr for SqrExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/exponential/sqrt/mod.rs
+++ b/rosy/src/program/expressions/functions/math/exponential/sqrt/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `SQRT(expr)` intrinsic function (square root).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct SqrtExpr {
     pub expr: Box<Expr>,
 }
@@ -122,8 +122,5 @@ impl TranspileableExpr for SqrtExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/lcd/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/lcd/mod.rs
@@ -38,7 +38,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -47,7 +47,7 @@ use std::collections::HashSet;
 /// LCD(ve) — DA memory size estimator (COSY compatibility).
 /// Takes a VE with (order & num_vars) and returns estimated DA memory size.
 /// Rosy doesn't need memory management, but returns a reasonable value.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LcdExpr {
     pub expr: Box<Expr>,
 }
@@ -107,8 +107,5 @@ impl TranspileableExpr for LcdExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/lcm/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/lcm/mod.rs
@@ -37,7 +37,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -45,7 +45,7 @@ use std::collections::HashSet;
 
 /// LCM(n) — Complex memory size estimator (COSY compatibility).
 /// Returns `2*n` as RE. Rosy doesn't need memory management.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LcmExpr {
     pub expr: Box<Expr>,
 }
@@ -105,8 +105,5 @@ impl TranspileableExpr for LcmExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/lda/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/lda/mod.rs
@@ -38,7 +38,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -47,7 +47,7 @@ use std::collections::HashSet;
 /// LDA(ve) — DA memory size estimator (COSY compatibility).
 /// Takes a VE with (order & num_vars) and returns estimated DA memory size.
 /// Rosy doesn't need memory management, but returns a reasonable value.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LdaExpr {
     pub expr: Box<Expr>,
 }
@@ -107,8 +107,5 @@ impl TranspileableExpr for LdaExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/llo/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/llo/mod.rs
@@ -40,7 +40,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -49,7 +49,7 @@ use std::collections::HashSet;
 /// LLO(n) — Logical memory size estimator (COSY compatibility).
 /// Returns `1` as RE. A logical always takes 1 unit of allocation.
 /// Rosy doesn't need memory management, but returns a value for backwards compatibility.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LloExpr {
     pub expr: Box<Expr>,
 }
@@ -109,8 +109,5 @@ impl TranspileableExpr for LloExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/lre/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/lre/mod.rs
@@ -40,7 +40,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -49,7 +49,7 @@ use std::collections::HashSet;
 /// LRE(n) — Real memory size estimator (COSY compatibility).
 /// Returns `1` as RE. A real always takes 1 unit of allocation.
 /// Rosy doesn't need memory management, but returns a value for backwards compatibility.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LreExpr {
     pub expr: Box<Expr>,
 }
@@ -109,8 +109,5 @@ impl TranspileableExpr for LreExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/lst/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/lst/mod.rs
@@ -40,7 +40,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -49,7 +49,7 @@ use std::collections::HashSet;
 /// LST(n) — String memory size estimator (COSY compatibility).
 /// Returns `n` as RE. Rosy doesn't need memory management, but returns
 /// a value for backwards compatibility.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LstExpr {
     pub expr: Box<Expr>,
 }
@@ -109,8 +109,5 @@ impl TranspileableExpr for LstExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/memory/lve/mod.rs
+++ b/rosy/src/program/expressions/functions/math/memory/lve/mod.rs
@@ -41,7 +41,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -50,7 +50,7 @@ use std::collections::HashSet;
 /// LVE(n) — Vector memory size estimator (COSY compatibility).
 /// Returns `n` as RE. A vector of n components takes n units of allocation.
 /// Rosy doesn't need memory management, but returns a value for backwards compatibility.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LveExpr {
     pub expr: Box<Expr>,
 }
@@ -110,8 +110,5 @@ impl TranspileableExpr for LveExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/query/isrt/mod.rs
+++ b/rosy/src/program/expressions/functions/math/query/isrt/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ISRT(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct IsrtExpr {
     pub expr: Box<Expr>,
 }
@@ -113,8 +113,5 @@ impl TranspileableExpr for IsrtExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/query/isrt3/mod.rs
+++ b/rosy/src/program/expressions/functions/math/query/isrt3/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ISRT3(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct Isrt3Expr {
     pub expr: Box<Expr>,
 }
@@ -113,8 +113,5 @@ impl TranspileableExpr for Isrt3Expr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/query/type_fn/mod.rs
+++ b/rosy/src/program/expressions/functions/math/query/type_fn/mod.rs
@@ -42,14 +42,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `TYPE(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TypeFnExpr {
     pub expr: Box<Expr>,
 }
@@ -113,8 +113,5 @@ impl TranspileableExpr for TypeFnExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/rounding/abs/mod.rs
+++ b/rosy/src/program/expressions/functions/math/rounding/abs/mod.rs
@@ -40,14 +40,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ABS(expr)` intrinsic function (absolute value).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct AbsExpr {
     pub expr: Box<Expr>,
 }
@@ -121,8 +121,5 @@ impl TranspileableExpr for AbsExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/rounding/cons/mod.rs
+++ b/rosy/src/program/expressions/functions/math/rounding/cons/mod.rs
@@ -40,14 +40,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `CONS(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ConsExpr {
     pub expr: Box<Expr>,
 }
@@ -127,8 +127,5 @@ impl TranspileableExpr for ConsExpr {
         // CONS has non-uniform type mapping (VE->RE, DA->RE, RE->RE, CM->CM),
         // so we cannot represent it with a type-preserving recipe.
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/rounding/int_fn/mod.rs
+++ b/rosy/src/program/expressions/functions/math/rounding/int_fn/mod.rs
@@ -37,14 +37,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `INT(expr)` intrinsic function (truncate toward zero).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct IntExpr {
     pub expr: Box<Expr>,
 }
@@ -118,8 +118,5 @@ impl TranspileableExpr for IntExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/rounding/nint/mod.rs
+++ b/rosy/src/program/expressions/functions/math/rounding/nint/mod.rs
@@ -37,14 +37,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `NINT(expr)` intrinsic function (round to nearest integer).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct NintExpr {
     pub expr: Box<Expr>,
 }
@@ -118,8 +118,5 @@ impl TranspileableExpr for NintExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/rounding/norm/mod.rs
+++ b/rosy/src/program/expressions/functions/math/rounding/norm/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `NORM(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct NormExpr {
     pub expr: Box<Expr>,
 }
@@ -125,8 +125,5 @@ impl TranspileableExpr for NormExpr {
         // NORM has non-uniform type mapping (DA->RE, VE->VE), so we cannot
         // represent it with a type-preserving recipe.
         ExprRecipe::Unknown
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/special/erf/mod.rs
+++ b/rosy/src/program/expressions/functions/math/special/erf/mod.rs
@@ -37,14 +37,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ERF(expr)` intrinsic function (real error function).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ErfExpr {
     pub expr: Box<Expr>,
 }
@@ -114,8 +114,5 @@ impl TranspileableExpr for ErfExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/special/werf/mod.rs
+++ b/rosy/src/program/expressions/functions/math/special/werf/mod.rs
@@ -37,14 +37,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `WERF(expr)` intrinsic function (Faddeeva function).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct WerfExpr {
     pub expr: Box<Expr>,
 }
@@ -114,8 +114,5 @@ impl TranspileableExpr for WerfExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/acos/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/acos/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ACOS(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct AcosExpr {
     pub expr: Box<Expr>,
 }
@@ -119,8 +119,5 @@ impl TranspileableExpr for AcosExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/asin/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/asin/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ASIN(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct AsinExpr {
     pub expr: Box<Expr>,
 }
@@ -119,8 +119,5 @@ impl TranspileableExpr for AsinExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/atan/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/atan/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `ATAN(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct AtanExpr {
     pub expr: Box<Expr>,
 }
@@ -119,8 +119,5 @@ impl TranspileableExpr for AtanExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/cos/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/cos/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `COS(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct CosExpr {
     pub expr: Box<Expr>,
 }
@@ -124,8 +124,5 @@ impl TranspileableExpr for CosExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/cosh/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/cosh/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `COSH(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct CoshExpr {
     pub expr: Box<Expr>,
 }
@@ -120,8 +120,5 @@ impl TranspileableExpr for CoshExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/sin/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/sin/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `SIN(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct SinExpr {
     pub expr: Box<Expr>,
 }
@@ -125,8 +125,5 @@ impl TranspileableExpr for SinExpr {
     ) -> ExprRecipe {
         let inner = resolver.build_expr_recipe(&self.expr, ctx, deps);
         ExprRecipe::TypePreserving(Box::new(inner))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/sinh/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/sinh/mod.rs
@@ -39,14 +39,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `SINH(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct SinhExpr {
     pub expr: Box<Expr>,
 }
@@ -120,8 +120,5 @@ impl TranspileableExpr for SinhExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/tan/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/tan/mod.rs
@@ -38,14 +38,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `TAN(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TanExpr {
     pub expr: Box<Expr>,
 }
@@ -121,8 +121,5 @@ impl TranspileableExpr for TanExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/trig/tanh/mod.rs
+++ b/rosy/src/program/expressions/functions/math/trig/tanh/mod.rs
@@ -40,14 +40,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `TANH(expr)` intrinsic function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TanhExpr {
     pub expr: Box<Expr>,
 }
@@ -121,8 +121,5 @@ impl TranspileableExpr for TanhExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::TypePreserving(Box::new(resolver.build_expr_recipe(&self.expr, ctx, deps)))
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/vector/vmax/mod.rs
+++ b/rosy/src/program/expressions/functions/math/vector/vmax/mod.rs
@@ -36,14 +36,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `VMAX(expr)` function (vector maximum).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VmaxExpr {
     pub expr: Box<Expr>,
 }
@@ -114,8 +114,5 @@ impl TranspileableExpr for VmaxExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/math/vector/vmin/mod.rs
+++ b/rosy/src/program/expressions/functions/math/vector/vmin/mod.rs
@@ -36,14 +36,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `VMIN(expr)` function (vector minimum).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VminExpr {
     pub expr: Box<Expr>,
 }
@@ -114,8 +114,5 @@ impl TranspileableExpr for VminExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/sys/length/mod.rs
+++ b/rosy/src/program/expressions/functions/sys/length/mod.rs
@@ -43,14 +43,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `LENGTH(expr)` system function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LengthExpr {
     pub expr: Box<Expr>,
 }
@@ -122,8 +122,5 @@ impl TranspileableExpr for LengthExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/sys/ltrim/mod.rs
+++ b/rosy/src/program/expressions/functions/sys/ltrim/mod.rs
@@ -36,14 +36,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `LTRIM(expr)` function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LtrimExpr {
     pub expr: Box<Expr>,
 }
@@ -111,8 +111,5 @@ impl TranspileableExpr for LtrimExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::ST())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/sys/position/mod.rs
+++ b/rosy/src/program/expressions/functions/sys/position/mod.rs
@@ -20,14 +20,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `POSITION(haystack, needle)` system function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct PositionExpr {
     pub haystack: Box<Expr>,
     pub needle: Box<Expr>,
@@ -124,8 +124,5 @@ impl TranspileableExpr for PositionExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/sys/trim/mod.rs
+++ b/rosy/src/program/expressions/functions/sys/trim/mod.rs
@@ -36,14 +36,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `TRIM(expr)` function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TrimExpr {
     pub expr: Box<Expr>,
 }
@@ -111,8 +111,5 @@ impl TranspileableExpr for TrimExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::ST())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/sys/varmem/mod.rs
+++ b/rosy/src/program/expressions/functions/sys/varmem/mod.rs
@@ -44,14 +44,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `VARMEM(expr)` system function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VarmemExpr {
     pub expr: Box<Expr>,
 }
@@ -123,8 +123,5 @@ impl TranspileableExpr for VarmemExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/functions/sys/varpoi/mod.rs
+++ b/rosy/src/program/expressions/functions/sys/varpoi/mod.rs
@@ -44,14 +44,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
 use std::collections::HashSet;
 
 /// AST node for the `VARPOI(expr)` system function.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct VarpoiExpr {
     pub expr: Box<Expr>,
 }
@@ -123,8 +123,5 @@ impl TranspileableExpr for VarpoiExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/mod.rs
+++ b/rosy/src/program/expressions/mod.rs
@@ -40,7 +40,7 @@ pub mod operators;
 pub mod types;
 
 use std::collections::HashSet;
-use crate::{ast::{FromRule, PRATT_PARSER, Rule}, resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot}, rosy_lib::RosyType, transpile::{TranspileableExpr, ExprFunctionCallResult, ConcatExtensionResult, add_context_to_all}};
+use crate::{ast::{FromRule, PRATT_PARSER, Rule}, resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot}, rosy_lib::RosyType, transpile::{TranspileableExpr, ExprFunctionCallResult, add_context_to_all}};
 use crate::transpile::{Transpile, TranspilationInputContext, TranspilationOutput};
 
 use crate::program::expressions::core::var_expr::VarExpr;
@@ -121,88 +121,8 @@ use crate::program::statements::SourceLocation;
 
 #[derive(Debug)]
 pub struct Expr {
-    pub enum_variant: ExprEnum,
     pub inner: Box<dyn TranspileableExpr>,
     pub source_location: SourceLocation,
-}
-impl PartialEq for Expr {
-    fn eq(&self, other: &Self) -> bool {
-        self.enum_variant == other.enum_variant
-    }
-}
-#[derive(Debug, PartialEq)]
-pub enum ExprEnum {
-    Number,
-    String,
-    Boolean,
-    Var,
-    Add,
-    Sub,
-    Mult,
-    Div,
-    Pow,
-    Eq,
-    Neq,
-    Lt,
-    Gt,
-    Lte,
-    Gte,
-    Not,
-    Concat,
-    Extract,
-    Complex,
-    StringConvert,
-    LogicalConvert,
-    DA,
-    CD,
-    Length,
-    Sin,
-    Cos,
-    Asin,
-    Acos,
-    Atan,
-    Sinh,
-    Cosh,
-    Tanh,
-    Sqr,
-    Sqrt,
-    Exp,
-    Log,
-    Tan,
-    Vmax,
-    Vmin,
-    Abs,
-    Norm,
-    Cons,
-    Int,
-    Nint,
-    TypeFn,
-    Trim,
-    Ltrim,
-    Isrt,
-    Isrt3,
-    Cmplx,
-    Conj,
-    Lst,
-    Lcm,
-    Lcd,
-    Lre,
-    Llo,
-    Lve,
-    Lda,
-    Neg,
-    Derive,
-    RealFn,
-    ImagFn,
-    ReConvert,
-    VeConvert,
-    Varmem,
-    Varpoi,
-    Erf,
-    Werf,
-    And,
-    Or,
-    Position,
 }
 
 impl FromRule for Expr {
@@ -219,7 +139,6 @@ impl FromRule for Expr {
                         .context("Failed to parse negation operand")?
                         .ok_or_else(|| anyhow::anyhow!("Expected expression in negation"))?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Neg,
                         inner: Box::new(NegExpr { operand: Box::new(operand) }),
                         source_location: loc,
                     })
@@ -239,7 +158,6 @@ impl FromRule for Expr {
                             let b = bool::from_rule(operand_pair)?
                                 .ok_or_else(|| anyhow::anyhow!("Expected boolean"))?;
                             Expr {
-                                enum_variant: ExprEnum::Boolean,
                                 inner: Box::new(b),
                                 source_location: op_loc,
                             }
@@ -249,7 +167,6 @@ impl FromRule for Expr {
                             let var_expr = VarExpr::from_rule(operand_pair)?
                                 .ok_or_else(|| anyhow::anyhow!("Expected VarExpr"))?;
                             Expr {
-                                enum_variant: ExprEnum::Var,
                                 inner: Box::new(var_expr),
                                 source_location: op_loc,
                             }
@@ -264,7 +181,6 @@ impl FromRule for Expr {
                     };
 
                     Ok(Expr {
-                        enum_variant: ExprEnum::Not,
                         inner: Box::new(NotExpr {
                             operand: Box::new(operand),
                         }),
@@ -274,7 +190,6 @@ impl FromRule for Expr {
                 Rule::variable_identifier => {
                     let var_expr = VarExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Var,
                         inner: Box::new(var_expr.ok_or_else(|| anyhow::anyhow!("Expected VarExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -282,7 +197,6 @@ impl FromRule for Expr {
                 Rule::number => {
                     let n = f64::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Number,
                         inner: Box::new(n.ok_or_else(|| anyhow::anyhow!("Expected number"))?),
                         source_location: loc.clone(),
                     })
@@ -290,7 +204,6 @@ impl FromRule for Expr {
                 Rule::boolean => {
                     let b = bool::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Boolean,
                         inner: Box::new(b.ok_or_else(|| anyhow::anyhow!("Expected boolean"))?),
                         source_location: loc.clone(),
                     })
@@ -298,7 +211,6 @@ impl FromRule for Expr {
                 Rule::string => {
                     let s = String::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::String,
                         inner: Box::new(s.ok_or_else(|| anyhow::anyhow!("Expected string"))?),
                         source_location: loc.clone(),
                     })
@@ -306,7 +218,6 @@ impl FromRule for Expr {
                 Rule::cm => {
                     let cm_expr = ComplexConvertExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Complex,
                         inner: Box::new(cm_expr.ok_or_else(|| anyhow::anyhow!("Expected ComplexConvertExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -314,7 +225,6 @@ impl FromRule for Expr {
                 Rule::st => {
                     let st_expr = StringConvertExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::StringConvert,
                         inner: Box::new(st_expr.ok_or_else(|| anyhow::anyhow!("Expected StringConvertExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -322,7 +232,6 @@ impl FromRule for Expr {
                 Rule::lo => {
                     let lo_expr = LogicalConvertExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::LogicalConvert,
                         inner: Box::new(lo_expr.ok_or_else(|| anyhow::anyhow!("Expected LogicalConvertExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -330,7 +239,6 @@ impl FromRule for Expr {
                 Rule::da => {
                     let da_expr = DAExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::DA,
                         inner: Box::new(da_expr.ok_or_else(|| anyhow::anyhow!("Expected DAExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -338,7 +246,6 @@ impl FromRule for Expr {
                 Rule::cd_intrinsic => {
                     let cd_expr = CDExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::CD,
                         inner: Box::new(cd_expr.ok_or_else(|| anyhow::anyhow!("Expected CDExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -346,7 +253,6 @@ impl FromRule for Expr {
                 Rule::position => {
                     let position_expr = PositionExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Position,
                         inner: Box::new(position_expr.ok_or_else(|| anyhow::anyhow!("Expected PositionExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -354,7 +260,6 @@ impl FromRule for Expr {
                 Rule::length => {
                     let length_expr = LengthExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Length,
                         inner: Box::new(length_expr.ok_or_else(|| anyhow::anyhow!("Expected LengthExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -362,7 +267,6 @@ impl FromRule for Expr {
                 Rule::sin => {
                     let sin_expr = SinExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Sin,
                         inner: Box::new(sin_expr.ok_or_else(|| anyhow::anyhow!("Expected SinExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -370,7 +274,6 @@ impl FromRule for Expr {
                 Rule::cos_fn => {
                     let cos_expr = CosExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Cos,
                         inner: Box::new(cos_expr.ok_or_else(|| anyhow::anyhow!("Expected CosExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -378,7 +281,6 @@ impl FromRule for Expr {
                 Rule::asin_fn => {
                     let asin_expr = AsinExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Asin,
                         inner: Box::new(asin_expr.ok_or_else(|| anyhow::anyhow!("Expected AsinExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -386,7 +288,6 @@ impl FromRule for Expr {
                 Rule::acos_fn => {
                     let acos_expr = AcosExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Acos,
                         inner: Box::new(acos_expr.ok_or_else(|| anyhow::anyhow!("Expected AcosExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -394,7 +295,6 @@ impl FromRule for Expr {
                 Rule::atan_fn => {
                     let atan_expr = AtanExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Atan,
                         inner: Box::new(atan_expr.ok_or_else(|| anyhow::anyhow!("Expected AtanExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -402,7 +302,6 @@ impl FromRule for Expr {
                 Rule::sinh_fn => {
                     let sinh_expr = SinhExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Sinh,
                         inner: Box::new(sinh_expr.ok_or_else(|| anyhow::anyhow!("Expected SinhExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -410,7 +309,6 @@ impl FromRule for Expr {
                 Rule::cosh_fn => {
                     let cosh_expr = CoshExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Cosh,
                         inner: Box::new(cosh_expr.ok_or_else(|| anyhow::anyhow!("Expected CoshExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -418,7 +316,6 @@ impl FromRule for Expr {
                 Rule::tanh_fn => {
                     let tanh_expr = TanhExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Tanh,
                         inner: Box::new(tanh_expr.ok_or_else(|| anyhow::anyhow!("Expected TanhExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -426,7 +323,6 @@ impl FromRule for Expr {
                 Rule::sqr => {
                     let sqr_expr = SqrExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Sqr,
                         inner: Box::new(sqr_expr.ok_or_else(|| anyhow::anyhow!("Expected SqrExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -434,7 +330,6 @@ impl FromRule for Expr {
                 Rule::sqrt_fn => {
                     let sqrt_expr = SqrtExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Sqrt,
                         inner: Box::new(sqrt_expr.ok_or_else(|| anyhow::anyhow!("Expected SqrtExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -442,7 +337,6 @@ impl FromRule for Expr {
                 Rule::exp_fn => {
                     let exp_expr = ExpExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Exp,
                         inner: Box::new(exp_expr.ok_or_else(|| anyhow::anyhow!("Expected ExpExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -450,7 +344,6 @@ impl FromRule for Expr {
                 Rule::log_fn => {
                     let log_expr = LogExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Log,
                         inner: Box::new(log_expr.ok_or_else(|| anyhow::anyhow!("Expected LogExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -458,7 +351,6 @@ impl FromRule for Expr {
                 Rule::tan_fn => {
                     let tan_expr = TanExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Tan,
                         inner: Box::new(tan_expr.ok_or_else(|| anyhow::anyhow!("Expected TanExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -466,7 +358,6 @@ impl FromRule for Expr {
                 Rule::vmax => {
                     let vmax_expr = VmaxExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Vmax,
                         inner: Box::new(vmax_expr.ok_or_else(|| anyhow::anyhow!("Expected VmaxExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -474,7 +365,6 @@ impl FromRule for Expr {
                 Rule::lst => {
                     let lst_expr = LstExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lst,
                         inner: Box::new(lst_expr.ok_or_else(|| anyhow::anyhow!("Expected LstExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -482,7 +372,6 @@ impl FromRule for Expr {
                 Rule::lcm => {
                     let lcm_expr = LcmExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lcm,
                         inner: Box::new(lcm_expr.ok_or_else(|| anyhow::anyhow!("Expected LcmExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -490,7 +379,6 @@ impl FromRule for Expr {
                 Rule::lcd => {
                     let lcd_expr = LcdExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lcd,
                         inner: Box::new(lcd_expr.ok_or_else(|| anyhow::anyhow!("Expected LcdExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -498,7 +386,6 @@ impl FromRule for Expr {
                 Rule::lre => {
                     let lre_expr = LreExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lre,
                         inner: Box::new(lre_expr.ok_or_else(|| anyhow::anyhow!("Expected LreExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -506,7 +393,6 @@ impl FromRule for Expr {
                 Rule::llo => {
                     let llo_expr = LloExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Llo,
                         inner: Box::new(llo_expr.ok_or_else(|| anyhow::anyhow!("Expected LloExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -514,7 +400,6 @@ impl FromRule for Expr {
                 Rule::lve => {
                     let lve_expr = LveExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lve,
                         inner: Box::new(lve_expr.ok_or_else(|| anyhow::anyhow!("Expected LveExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -522,7 +407,6 @@ impl FromRule for Expr {
                 Rule::lda => {
                     let lda_expr = LdaExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lda,
                         inner: Box::new(lda_expr.ok_or_else(|| anyhow::anyhow!("Expected LdaExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -530,7 +414,6 @@ impl FromRule for Expr {
                 Rule::vmin => {
                     let vmin_expr = VminExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Vmin,
                         inner: Box::new(vmin_expr.ok_or_else(|| anyhow::anyhow!("Expected VminExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -538,7 +421,6 @@ impl FromRule for Expr {
                 Rule::abs_fn => {
                     let abs_expr = AbsExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Abs,
                         inner: Box::new(abs_expr.ok_or_else(|| anyhow::anyhow!("Expected AbsExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -546,7 +428,6 @@ impl FromRule for Expr {
                 Rule::norm_fn => {
                     let norm_expr = NormExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Norm,
                         inner: Box::new(norm_expr.ok_or_else(|| anyhow::anyhow!("Expected NormExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -554,7 +435,6 @@ impl FromRule for Expr {
                 Rule::cons_fn => {
                     let cons_expr = ConsExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Cons,
                         inner: Box::new(cons_expr.ok_or_else(|| anyhow::anyhow!("Expected ConsExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -562,7 +442,6 @@ impl FromRule for Expr {
                 Rule::int_fn => {
                     let int_expr = IntExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Int,
                         inner: Box::new(int_expr.ok_or_else(|| anyhow::anyhow!("Expected IntExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -570,7 +449,6 @@ impl FromRule for Expr {
                 Rule::nint_fn => {
                     let nint_expr = NintExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Nint,
                         inner: Box::new(nint_expr.ok_or_else(|| anyhow::anyhow!("Expected NintExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -578,7 +456,6 @@ impl FromRule for Expr {
                 Rule::type_fn => {
                     let type_fn_expr = TypeFnExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::TypeFn,
                         inner: Box::new(type_fn_expr.ok_or_else(|| anyhow::anyhow!("Expected TypeFnExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -586,7 +463,6 @@ impl FromRule for Expr {
                 Rule::trim_fn => {
                     let trim_expr = TrimExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Trim,
                         inner: Box::new(trim_expr.ok_or_else(|| anyhow::anyhow!("Expected TrimExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -594,7 +470,6 @@ impl FromRule for Expr {
                 Rule::ltrim_fn => {
                     let ltrim_expr = LtrimExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Ltrim,
                         inner: Box::new(ltrim_expr.ok_or_else(|| anyhow::anyhow!("Expected LtrimExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -602,7 +477,6 @@ impl FromRule for Expr {
                 Rule::isrt_fn => {
                     let isrt_expr = IsrtExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Isrt,
                         inner: Box::new(isrt_expr.ok_or_else(|| anyhow::anyhow!("Expected IsrtExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -610,7 +484,6 @@ impl FromRule for Expr {
                 Rule::isrt3_fn => {
                     let isrt3_expr = Isrt3Expr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Isrt3,
                         inner: Box::new(isrt3_expr.ok_or_else(|| anyhow::anyhow!("Expected Isrt3Expr"))?),
                         source_location: loc.clone(),
                     })
@@ -618,7 +491,6 @@ impl FromRule for Expr {
                 Rule::cmplx_fn => {
                     let cmplx_expr = CmplxExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Cmplx,
                         inner: Box::new(cmplx_expr.ok_or_else(|| anyhow::anyhow!("Expected CmplxExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -626,7 +498,6 @@ impl FromRule for Expr {
                 Rule::conj_fn => {
                     let conj_expr = ConjExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Conj,
                         inner: Box::new(conj_expr.ok_or_else(|| anyhow::anyhow!("Expected ConjExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -634,7 +505,6 @@ impl FromRule for Expr {
                 Rule::real_fn => {
                     let real_fn_expr = RealFnExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::RealFn,
                         inner: Box::new(real_fn_expr.ok_or_else(|| anyhow::anyhow!("Expected RealFnExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -642,7 +512,6 @@ impl FromRule for Expr {
                 Rule::imag_fn => {
                     let imag_fn_expr = ImagFnExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::ImagFn,
                         inner: Box::new(imag_fn_expr.ok_or_else(|| anyhow::anyhow!("Expected ImagFnExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -650,7 +519,6 @@ impl FromRule for Expr {
                 Rule::re_fn => {
                     let re_convert_expr = ReConvertExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::ReConvert,
                         inner: Box::new(re_convert_expr.ok_or_else(|| anyhow::anyhow!("Expected ReConvertExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -658,7 +526,6 @@ impl FromRule for Expr {
                 Rule::ve_fn => {
                     let ve_convert_expr = VeConvertExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::VeConvert,
                         inner: Box::new(ve_convert_expr.ok_or_else(|| anyhow::anyhow!("Expected VeConvertExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -666,7 +533,6 @@ impl FromRule for Expr {
                 Rule::varmem => {
                     let varmem_expr = VarmemExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Varmem,
                         inner: Box::new(varmem_expr.ok_or_else(|| anyhow::anyhow!("Expected VarmemExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -674,7 +540,6 @@ impl FromRule for Expr {
                 Rule::varpoi => {
                     let varpoi_expr = VarpoiExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Varpoi,
                         inner: Box::new(varpoi_expr.ok_or_else(|| anyhow::anyhow!("Expected VarpoiExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -682,7 +547,6 @@ impl FromRule for Expr {
                 Rule::erf_fn => {
                     let erf_expr = ErfExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Erf,
                         inner: Box::new(erf_expr.ok_or_else(|| anyhow::anyhow!("Expected ErfExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -690,7 +554,6 @@ impl FromRule for Expr {
                 Rule::werf_fn => {
                     let werf_expr = WerfExpr::from_rule(primary)?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Werf,
                         inner: Box::new(werf_expr.ok_or_else(|| anyhow::anyhow!("Expected WerfExpr"))?),
                         source_location: loc.clone(),
                     })
@@ -715,7 +578,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `add` expression")?;
                     let right = right.context("...while transpiling right-hand side of `add` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Add,
                         inner: Box::new(AddExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -726,7 +588,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `sub` expression")?;
                     let right = right.context("...while transpiling right-hand side of `sub` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Sub,
                         inner: Box::new(SubExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -737,7 +598,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `mult` expression")?;
                     let right = right.context("...while transpiling right-hand side of `mult` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Mult,
                         inner: Box::new(MultExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -748,7 +608,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `div` expression")?;
                     let right = right.context("...while transpiling right-hand side of `div` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Div,
                         inner: Box::new(DivExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -759,7 +618,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling base of `pow` expression")?;
                     let right = right.context("...while transpiling exponent of `pow` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Pow,
                         inner: Box::new(PowExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -769,27 +627,17 @@ impl FromRule for Expr {
                 Rule::concat => {
                     let left = left.context("...while transpiling left-hand side of `concat` expression")?;
                     let right = right.context("...while transpiling right-hand side of `concat` expression")?;
-
-                    // If left is already a Concat, extend its terms instead of nesting
-                    if left.enum_variant == ExprEnum::Concat {
-                        let mut left = left;
-                        match left.inner.extend_concat(right) {
-                            ConcatExtensionResult::Extended => Ok(left),
-                            ConcatExtensionResult::NotAConcatExpr => bail!("Failed to extend Concat expression - internal inconsistency"),
-                        }
-                    } else {
-                        let terms = vec![left, right];
-                        Ok(Expr {
-                            enum_variant: ExprEnum::Concat,
-                            inner: Box::new(ConcatExpr { terms })
-                        , source_location: op_loc.clone() })
-                    }
+                    Ok(Expr {
+                        inner: Box::new(ConcatExpr {
+                            left: Box::new(left),
+                            right: Box::new(right),
+                        })
+                    , source_location: op_loc.clone() })
                 },
                 Rule::extract => {
                     let left = left.context("...while transpiling object of `extract` expression")?;
                     let right = right.context("...while transpiling index of `extract` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Extract,
                         inner: Box::new(ExtractExpr {
                             object: Box::new(left),
                             index: Box::new(right),
@@ -800,7 +648,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling object of `derive` (%) expression")?;
                     let right = right.context("...while transpiling index of `derive` (%) expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Derive,
                         inner: Box::new(DeriveExpr {
                             object: Box::new(left),
                             index: Box::new(right),
@@ -811,7 +658,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `eq` expression")?;
                     let right = right.context("...while transpiling right-hand side of `eq` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Eq,
                         inner: Box::new(EqExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -822,7 +668,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `neq` expression")?;
                     let right = right.context("...while transpiling right-hand side of `neq` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Neq,
                         inner: Box::new(NeqExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -833,7 +678,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `lt` expression")?;
                     let right = right.context("...while transpiling right-hand side of `lt` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lt,
                         inner: Box::new(LtExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -844,7 +688,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `gt` expression")?;
                     let right = right.context("...while transpiling right-hand side of `gt` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Gt,
                         inner: Box::new(GtExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -855,7 +698,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `lte` expression")?;
                     let right = right.context("...while transpiling right-hand side of `lte` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Lte,
                         inner: Box::new(LteExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -866,7 +708,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `gte` expression")?;
                     let right = right.context("...while transpiling right-hand side of `gte` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Gte,
                         inner: Box::new(GteExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -877,7 +718,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `AND` expression")?;
                     let right = right.context("...while transpiling right-hand side of `AND` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::And,
                         inner: Box::new(AndExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -888,7 +728,6 @@ impl FromRule for Expr {
                     let left = left.context("...while transpiling left-hand side of `OR` expression")?;
                     let right = right.context("...while transpiling right-hand side of `OR` expression")?;
                     Ok(Expr {
-                        enum_variant: ExprEnum::Or,
                         inner: Box::new(OrExpr {
                             left: Box::new(left),
                             right: Box::new(right),
@@ -921,9 +760,6 @@ impl TranspileableExpr for Expr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         self.inner.build_expr_recipe(resolver, ctx, deps)
-    }
-    fn extend_concat(&mut self, right: Expr) -> ConcatExtensionResult {
-        self.inner.extend_concat(right)
     }
 }
 impl Transpile for Expr {

--- a/rosy/src/program/expressions/operators/arithmetic/add/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/add/mod.rs
@@ -57,14 +57,14 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the binary addition operator (`+`).
 ///
 /// Created by the Pratt parser during expression parsing.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct AddExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -113,9 +113,6 @@ impl TranspileableExpr for AddExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for AddExpr {

--- a/rosy/src/program/expressions/operators/arithmetic/div/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/div/mod.rs
@@ -53,13 +53,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use std::collections::{BTreeSet, HashSet};
 
 /// AST node for the binary division operator (`/`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct DivExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -108,9 +108,6 @@ impl TranspileableExpr for DivExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for DivExpr {

--- a/rosy/src/program/expressions/operators/arithmetic/mult/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/mult/mod.rs
@@ -55,13 +55,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use std::collections::{BTreeSet, HashSet};
 
 /// AST node for the binary multiplication operator (`*`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct MultExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -110,9 +110,6 @@ impl TranspileableExpr for MultExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for MultExpr {

--- a/rosy/src/program/expressions/operators/arithmetic/sub/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/sub/mod.rs
@@ -53,13 +53,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use std::collections::{BTreeSet, HashSet};
 
 /// AST node for the binary subtraction operator (`-`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct SubExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -108,9 +108,6 @@ impl TranspileableExpr for SubExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for SubExpr {

--- a/rosy/src/program/expressions/operators/collection/concat/mod.rs
+++ b/rosy/src/program/expressions/operators/collection/concat/mod.rs
@@ -1,13 +1,11 @@
 //! # Concatenation Operator (`&`)
 //!
 //! Concatenates scalars and vectors into larger vectors, or strings together.
-//! Multiple `&` operators in a row are flattened into a single `ConcatExpr`
-//! with multiple terms for efficient code generation.
 //!
 //! ## Syntax
 //!
 //! ```text
-//! expr & expr & ...
+//! expr & expr
 //! ```
 //!
 //! ## Type Compatibility
@@ -40,63 +38,55 @@
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::rosy_lib::{RosyBaseType, RosyType};
+use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
-use anyhow::{Context, Error, Result, anyhow};
+use anyhow::{Context, Error, Result};
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 
 /// AST node for the concatenation operator (`&`).
-///
-/// Unlike other binary operators, concatenation flattens chains:
-/// `a & b & c` becomes `ConcatExpr { terms: [a, b, c] }` rather than nested nodes.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ConcatExpr {
-    pub terms: Vec<Expr>,
+    pub left: Box<Expr>,
+    pub right: Box<Expr>,
 }
 
 impl FromRule for ConcatExpr {
     fn from_rule(_pair: pest::iterators::Pair<Rule>) -> Result<Option<Self>> {
-        // ConcatExpr is created by the infix parser, not directly from a rule
         anyhow::bail!("ConcatExpr should be created by infix parser, not FromRule")
     }
 }
 impl TranspileableExpr for ConcatExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        let mut r#type = self
-            .terms
-            .last()
-            .ok_or(anyhow::anyhow!("Cannot concatenate zero terms!"))?
+        let left_type = self
+            .left
             .type_of(context)
-            .context("...while determining type of last term in concatenation")?;
+            .context("...while determining type of left side of concatenation")?;
+        let right_type = self
+            .right
+            .type_of(context)
+            .context("...while determining type of right side of concatenation")?;
 
-        for term_expr in self.terms.iter().rev().skip(1) {
-            let term_type = term_expr
-                .type_of(context)
-                .context("...while determining type of term in concatenation")?;
-
-            r#type = crate::rosy_lib::operators::concat::get_return_type(&r#type, &term_type)
-                .ok_or(anyhow::anyhow!(
-                    "Cannot concatenate types '{}' and '{}' together!",
-                    r#type,
-                    term_type
-                ))?;
-        }
-
-        Ok(r#type)
+        crate::rosy_lib::operators::concat::get_return_type(&left_type, &right_type)
+            .ok_or(anyhow::anyhow!(
+                "Cannot concatenate types '{}' and '{}' together!",
+                left_type,
+                right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
     ) -> ExprFunctionCallResult {
-        for term in &self.terms {
-            if let Err(e) = resolver.discover_expr_function_calls(term, ctx) {
-                return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
-            }
+        if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
+            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+        }
+        if let Err(e) = resolver.discover_expr_function_calls(&self.right, ctx) {
+            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
         }
         ExprFunctionCallResult::HasFunctionCalls { result: Ok(()) }
     }
@@ -106,16 +96,9 @@ impl TranspileableExpr for ConcatExpr {
         ctx: &ScopeContext,
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
-        let recipes: Vec<ExprRecipe> = self
-            .terms
-            .iter()
-            .map(|t| resolver.build_expr_recipe(t, ctx, deps))
-            .collect();
-        ExprRecipe::Concat(recipes)
-    }
-    fn extend_concat(&mut self, right: Expr) -> ConcatExtensionResult {
-        self.terms.push(right);
-        ConcatExtensionResult::Extended
+        let left = resolver.build_expr_recipe(&self.left, ctx, deps);
+        let right = resolver.build_expr_recipe(&self.right, ctx, deps);
+        ExprRecipe::Concat(Box::new(left), Box::new(right))
     }
 }
 impl Transpile for ConcatExpr {
@@ -123,149 +106,32 @@ impl Transpile for ConcatExpr {
         &self,
         context: &mut TranspilationInputContext,
     ) -> Result<TranspilationOutput, Vec<Error>> {
-        // First, do a type check
+        // Type check
         let _ = self
             .type_of(context)
             .map_err(|e| vec![e.context("...while verifying types of concatenation expression")])?;
 
-        // Check if all terms are the same scalar type for direct emission
-        let term_types: Vec<_> = self
-            .terms
-            .iter()
-            .map(|t| t.type_of(context))
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| vec![e])?;
+        let left_output = self.left.transpile(context)
+            .map_err(|errs| errs.into_iter()
+                .map(|e| e.context("...while transpiling left side of concatenation"))
+                .collect::<Vec<_>>())?;
+        let right_output = self.right.transpile(context)
+            .map_err(|errs| errs.into_iter()
+                .map(|e| e.context("...while transpiling right side of concatenation"))
+                .collect::<Vec<_>>())?;
 
-        let all_re_scalar = term_types
-            .iter()
-            .all(|t| t.base_type == RosyBaseType::RE && t.dimensions == 0);
-        let all_st_scalar = term_types
-            .iter()
-            .all(|t| t.base_type == RosyBaseType::ST && t.dimensions == 0);
-
-        // Direct vec![...] emission for all-RE terms (avoids N-1 intermediate allocations)
-        if all_re_scalar {
-            let mut parts = Vec::new();
-            let mut requested_variables = BTreeSet::new();
-            let mut errors = Vec::new();
-            for (i, term) in self.terms.iter().enumerate() {
-                match term.transpile(context) {
-                    Ok(output) => {
-                        requested_variables.extend(output.requested_variables.iter().cloned());
-                        parts.push(output.as_value());
-                    }
-                    Err(mut e) => {
-                        for err in e.drain(..) {
-                            errors.push(err.context(format!(
-                                "...while transpiling term {} of concatenation",
-                                i + 1
-                            )));
-                        }
-                    }
-                }
-            }
-            return if errors.is_empty() {
-                Ok(TranspilationOutput {
-                    serialization: format!("vec![{}]", parts.join(", ")),
-                    requested_variables,
-                    value_kind: ValueKind::Owned,
-                })
-            } else {
-                Err(errors)
-            };
-        }
-
-        // Direct format!(...) emission for all-ST terms (single allocation)
-        if all_st_scalar {
-            let mut parts = Vec::new();
-            let mut requested_variables = BTreeSet::new();
-            let mut errors = Vec::new();
-            for (i, term) in self.terms.iter().enumerate() {
-                match term.transpile(context) {
-                    Ok(output) => {
-                        requested_variables.extend(output.requested_variables.iter().cloned());
-                        parts.push(output.as_ref());
-                    }
-                    Err(mut e) => {
-                        for err in e.drain(..) {
-                            errors.push(err.context(format!(
-                                "...while transpiling term {} of concatenation",
-                                i + 1
-                            )));
-                        }
-                    }
-                }
-            }
-            return if errors.is_empty() {
-                Ok(TranspilationOutput {
-                    serialization: format!(
-                        "format!(\"{}\"{})",
-                        "{}".repeat(parts.len()),
-                        parts.iter().map(|p| format!(", {p}")).collect::<String>()
-                    ),
-                    requested_variables,
-                    value_kind: ValueKind::Owned,
-                })
-            } else {
-                Err(errors)
-            };
-        }
-
-        // General case: accumulator-based chaining via RosyConcat trait
         let mut requested_variables = BTreeSet::new();
-        let mut errors = Vec::new();
+        requested_variables.extend(left_output.requested_variables.iter().cloned());
+        requested_variables.extend(right_output.requested_variables.iter().cloned());
 
-        let first_term = self.terms.get(0).ok_or(vec![anyhow!(
-            "Concatenation expression must have at least one term!"
-        )])?;
-        let mut accumulator = match first_term.transpile(context) {
-            Ok(output) => {
-                requested_variables.extend(output.requested_variables.iter().cloned());
-                output
-            }
-            Err(mut e) => {
-                for err in e.drain(..) {
-                    errors.push(err.context("...while transpiling first term of concatenation"));
-                }
-                TranspilationOutput::default()
-            }
-        };
-
-        for (i, term) in self.terms.iter().skip(1).enumerate() {
-            let term_output = match term.transpile(context) {
-                Ok(output) => {
-                    requested_variables.extend(output.requested_variables.iter().cloned());
-                    output
-                }
-                Err(mut vec_err) => {
-                    for err in vec_err.drain(..) {
-                        errors.push(err.context(format!(
-                            "...while transpiling term {} of concatenation",
-                            i + 2
-                        )));
-                    }
-                    TranspilationOutput::default()
-                }
-            };
-            accumulator = TranspilationOutput {
-                serialization: format!(
-                    "RosyConcat::rosy_concat({}, {})?",
-                    accumulator.as_ref(),
-                    term_output.as_ref()
-                ),
-                requested_variables: BTreeSet::new(),
-                value_kind: ValueKind::Owned,
-            };
-        }
-
-        if errors.is_empty() {
-            Ok(TranspilationOutput {
-                serialization: accumulator.serialization,
-                requested_variables,
-                value_kind: ValueKind::Owned,
-            })
-        } else {
-            Err(errors)
-        }
+        Ok(TranspilationOutput {
+            serialization: format!(
+                "RosyConcat::rosy_concat({}, {})?",
+                left_output.as_ref(),
+                right_output.as_ref()
+            ),
+            requested_variables,
+            value_kind: ValueKind::Owned,
+        })
     }
 }

--- a/rosy/src/program/expressions/operators/collection/derive/mod.rs
+++ b/rosy/src/program/expressions/operators/collection/derive/mod.rs
@@ -37,7 +37,7 @@ use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Context as AnyhowContext, Error, Result};
@@ -45,7 +45,7 @@ use std::collections::{BTreeSet, HashSet};
 
 /// DA%n = partial derivative w.r.t. variable n (positive n)
 /// DA%(-n) = anti-derivative (integral) w.r.t. variable n (negative n)
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct DeriveExpr {
     pub object: Box<Expr>,
     pub index: Box<Expr>,
@@ -119,8 +119,5 @@ impl TranspileableExpr for DeriveExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }

--- a/rosy/src/program/expressions/operators/collection/extract/mod.rs
+++ b/rosy/src/program/expressions/operators/collection/extract/mod.rs
@@ -45,12 +45,12 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{BinaryOpKind, ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result};
 
 /// AST node for the extraction operator (`|`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ExtractExpr {
     pub object: Box<Expr>,
     pub index: Box<Expr>,
@@ -108,9 +108,6 @@ impl TranspileableExpr for ExtractExpr {
             left: Box::new(left),
             right: Box::new(right),
         }
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for ExtractExpr {

--- a/rosy/src/program/expressions/operators/comparison/eq/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/eq/mod.rs
@@ -40,12 +40,12 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the equality operator (`=`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct EqExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -88,9 +88,6 @@ impl TranspileableExpr for EqExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for EqExpr {

--- a/rosy/src/program/expressions/operators/comparison/gt/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/gt/mod.rs
@@ -39,12 +39,12 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the greater-than operator (`>`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct GtExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -86,9 +86,6 @@ impl TranspileableExpr for GtExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for GtExpr {

--- a/rosy/src/program/expressions/operators/comparison/gte/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/gte/mod.rs
@@ -32,12 +32,12 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the greater-than-or-equal operator (`>=`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct GteExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -79,9 +79,6 @@ impl TranspileableExpr for GteExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for GteExpr {

--- a/rosy/src/program/expressions/operators/comparison/lt/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/lt/mod.rs
@@ -40,12 +40,12 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the less-than operator (`<`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LtExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -87,9 +87,6 @@ impl TranspileableExpr for LtExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for LtExpr {

--- a/rosy/src/program/expressions/operators/comparison/lte/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/lte/mod.rs
@@ -32,12 +32,12 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the less-than-or-equal operator (`<=`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct LteExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -79,9 +79,6 @@ impl TranspileableExpr for LteExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for LteExpr {

--- a/rosy/src/program/expressions/operators/comparison/neq/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/neq/mod.rs
@@ -41,12 +41,12 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the not-equal operator (`<>`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct NeqExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -89,9 +89,6 @@ impl TranspileableExpr for NeqExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for NeqExpr {

--- a/rosy/src/program/expressions/operators/logical/and_op/mod.rs
+++ b/rosy/src/program/expressions/operators/logical/and_op/mod.rs
@@ -21,12 +21,12 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the logical AND operator.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct AndExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -68,9 +68,6 @@ impl TranspileableExpr for AndExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for AndExpr {

--- a/rosy/src/program/expressions/operators/logical/or_op/mod.rs
+++ b/rosy/src/program/expressions/operators/logical/or_op/mod.rs
@@ -21,12 +21,12 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// AST node for the logical OR operator.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct OrExpr {
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -68,9 +68,6 @@ impl TranspileableExpr for OrExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for OrExpr {

--- a/rosy/src/program/expressions/operators/unary/neg/mod.rs
+++ b/rosy/src/program/expressions/operators/unary/neg/mod.rs
@@ -37,14 +37,14 @@ use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
 use crate::transpile::{
-    ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
+    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput,
     Transpile, TranspileableExpr, ValueKind,
 };
 use anyhow::{Error, Result, anyhow};
 
 /// Unary negation expression: `-expr`
 /// Transpiled as `0 - expr` using the existing subtraction operator.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct NegExpr {
     pub operand: Box<Expr>,
 }
@@ -87,9 +87,6 @@ impl TranspileableExpr for NegExpr {
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         resolver.build_expr_recipe(&self.operand, ctx, deps)
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 

--- a/rosy/src/program/expressions/operators/unary/not/mod.rs
+++ b/rosy/src/program/expressions/operators/unary/not/mod.rs
@@ -38,13 +38,13 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::rosy_lib::RosyType;
-use crate::transpile::{ConcatExtensionResult, ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 
 /// Logical NOT expression (unary operator).
 /// Supports both `!x` and `NOT x` syntax.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct NotExpr {
     pub operand: Box<Expr>,
 }
@@ -79,9 +79,6 @@ impl TranspileableExpr for NotExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for NotExpr {

--- a/rosy/src/program/expressions/types/boolean/mod.rs
+++ b/rosy/src/program/expressions/types/boolean/mod.rs
@@ -30,12 +30,11 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use anyhow::{Error, Result, bail};
 use std::collections::{BTreeSet, HashSet};
 
-use crate::program::expressions::Expr;
 use crate::{
     ast::{FromRule, Rule},
     rosy_lib::RosyType,
     transpile::{
-        ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext,
+        ExprFunctionCallResult, TranspilationInputContext,
         TranspilationOutput, Transpile, TranspileableExpr, ValueKind,
     },
 };
@@ -73,9 +72,6 @@ impl TranspileableExpr for bool {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::LO())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for bool {

--- a/rosy/src/program/expressions/types/cd/mod.rs
+++ b/rosy/src/program/expressions/types/cd/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     ast::{FromRule, Rule},
     program::expressions::Expr,
     transpile::{
-        ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext,
+        ExprFunctionCallResult, TranspilationInputContext,
         TranspilationOutput, Transpile, TranspileableExpr, ValueKind,
     },
 };
@@ -40,7 +40,7 @@ use anyhow::{Context, Error};
 use std::collections::HashSet;
 
 /// AST node for the `CD(n)` constructor expression.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct CDExpr {
     pub index: Box<Expr>,
 }
@@ -82,9 +82,6 @@ impl TranspileableExpr for CDExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::CD())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for CDExpr {

--- a/rosy/src/program/expressions/types/da/mod.rs
+++ b/rosy/src/program/expressions/types/da/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     ast::{FromRule, Rule},
     program::expressions::Expr,
     transpile::{
-        ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext,
+        ExprFunctionCallResult, TranspilationInputContext,
         TranspilationOutput, Transpile, TranspileableExpr, ValueKind,
     },
 };
@@ -40,7 +40,7 @@ use anyhow::{Context, Error};
 use std::collections::HashSet;
 
 /// AST node for the `DA(n)` constructor expression.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct DAExpr {
     pub index: Box<Expr>,
 }
@@ -82,9 +82,6 @@ impl TranspileableExpr for DAExpr {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::DA())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for DAExpr {

--- a/rosy/src/program/expressions/types/number/mod.rs
+++ b/rosy/src/program/expressions/types/number/mod.rs
@@ -31,7 +31,6 @@
 #![doc = include_str!("cosy_output.txt")]
 //! ```
 
-use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use anyhow::{Error, Result};
 use std::collections::{BTreeSet, HashSet};
@@ -40,7 +39,7 @@ use crate::{
     ast::{FromRule, Rule},
     rosy_lib::RosyType,
     transpile::{
-        ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext,
+        ExprFunctionCallResult, TranspilationInputContext,
         TranspilationOutput, Transpile, TranspileableExpr, ValueKind,
     },
 };
@@ -74,9 +73,6 @@ impl TranspileableExpr for f64 {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::RE())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for f64 {

--- a/rosy/src/program/expressions/types/string/mod.rs
+++ b/rosy/src/program/expressions/types/string/mod.rs
@@ -33,12 +33,11 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use anyhow::{Error, Result};
 use std::collections::{BTreeSet, HashSet};
 
-use crate::program::expressions::Expr;
 use crate::{
     ast::{FromRule, Rule},
     rosy_lib::RosyType,
     transpile::{
-        ConcatExtensionResult, ExprFunctionCallResult, TranspilationInputContext,
+        ExprFunctionCallResult, TranspilationInputContext,
         TranspilationOutput, Transpile, TranspileableExpr, ValueKind,
     },
 };
@@ -79,9 +78,6 @@ impl TranspileableExpr for String {
         _deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe {
         ExprRecipe::Literal(RosyType::ST())
-    }
-    fn extend_concat(&mut self, _right: Expr) -> ConcatExtensionResult {
-        ConcatExtensionResult::NotAConcatExpr
     }
 }
 impl Transpile for String {

--- a/rosy/src/program/statements/core/function/mod.rs
+++ b/rosy/src/program/statements/core/function/mod.rs
@@ -121,7 +121,6 @@ impl FromRule for FunctionStatement {
 
         let body = {
             let mut statements = vec![Statement {
-                enum_variant: StatementEnum::VarDecl,
                 inner: Box::new(VarDeclStatement {
                     data: VariableDeclarationData {
                         name: name.clone(),

--- a/rosy/src/program/statements/mod.rs
+++ b/rosy/src/program/statements/mod.rs
@@ -212,109 +212,8 @@ impl SourceLocation {
 
 #[derive(Debug)]
 pub struct Statement {
-    pub enum_variant: StatementEnum,
     pub inner: Box<dyn TranspileableStatement>,
     pub source_location: SourceLocation,
-}
-#[derive(Debug)]
-pub enum StatementEnum {
-    DAInit,
-    DaPrv,
-    DaRev,
-    VarDecl,
-    Write,
-    Writeb,
-    Read,
-    Readb,
-    Openf,
-    Openfb,
-    Closef,
-    Assign,
-    Procedure,
-    ProcedureCall,
-    Function,
-    FunctionCall,
-    Loop,
-    WhileLoop,
-    PLoop,
-    If,
-    Break,
-    Fit,
-    Cpusec,
-    DaEps,
-    DaNot,
-    DaTrn,
-    Ldet,
-    Linv,
-    OsCall,
-    Polval,
-    Quit,
-    Scrlen,
-    Substr,
-    Velget,
-    Velset,
-    Vedot,
-    Veunit,
-    Vezero,
-    Stcre,
-    Recst,
-    Ranseed,
-    Reran,
-    Pwtime,
-    Pnpro,
-    Imunit,
-    Lev,
-    Lsline,
-    Mblock,
-    Mtree,
-    Rkco,
-    DaScl,
-    DaSgn,
-    DaDer,
-    DaInt,
-    DaNoro,
-    DaNors,
-    DaPlu,
-    DaDiu,
-    DaDmu,
-    DaCliw,
-    DaCqlc,
-    DaArea,
-    DaPew,
-    DaPee,
-    DaPea,
-    DaPep,
-    DaEst,
-    DaEpsm,
-    Epsmin,
-    DaFset,
-    DaFilt,
-    DaNotw,
-    DaFlo,
-    CdFlo,
-    DaGmd,
-    DaNow,
-    Cdf2,
-    Cdnf,
-    Cdnfda,
-    Cdnfds,
-    DaRan,
-    DaCode,
-    Sleepm,
-    Argget,
-    Memdpv,
-    Memfre,
-    Memall,
-    Memwrt,
-    Ltrue,
-    Lfalse,
-    Readm,
-    Writem,
-    Rewf,
-    Backf,
-    Reads,
-    Intpol,
-    Save,
 }
 impl TranspileableStatement for Statement {
     fn register_typeslot_declaration(
@@ -351,7 +250,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DAInit,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -361,7 +259,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaPrv,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -371,7 +268,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaRev,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -381,7 +277,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::VarDecl,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -391,7 +286,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Write,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -400,7 +294,6 @@ impl FromRule for Statement {
                 .context("...while building READS statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Reads,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -410,7 +303,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Read,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -420,7 +312,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Writeb,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -430,7 +321,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Readb,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -440,7 +330,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Openf,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -450,7 +339,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Openfb,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -460,7 +348,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Closef,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -469,7 +356,6 @@ impl FromRule for Statement {
                 .context("...while building REWF statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Rewf,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -478,7 +364,6 @@ impl FromRule for Statement {
                 .context("...while building BACKF statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Backf,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -488,7 +373,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Assign,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -498,7 +382,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Loop,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -508,7 +391,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::WhileLoop,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -518,7 +400,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::PLoop,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -528,7 +409,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Procedure,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -538,7 +418,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::ProcedureCall,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -548,7 +427,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Function,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -558,7 +436,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::FunctionCall,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -568,7 +445,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::If,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -578,7 +454,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Break,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -588,7 +463,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Fit,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -599,7 +473,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Scrlen,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -609,7 +482,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Cpusec,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -619,7 +491,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Quit,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -629,7 +500,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::OsCall,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -639,7 +509,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaNot,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -649,7 +518,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaEps,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -659,7 +527,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaTrn,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -669,7 +536,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Linv,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -679,7 +545,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Ldet,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -689,7 +554,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Substr,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -699,7 +563,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Velset,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -709,7 +572,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Velget,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -719,7 +581,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Save,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -728,7 +589,6 @@ impl FromRule for Statement {
                 .context("...while building INTPOL statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Intpol,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -738,7 +598,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Polval,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -748,7 +607,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Vedot,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -758,7 +616,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Veunit,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -768,7 +625,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Vezero,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -778,7 +634,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Stcre,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -788,7 +643,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Recst,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -798,7 +652,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Reran,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -808,7 +661,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Ranseed,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -818,7 +670,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Pwtime,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -828,7 +679,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Pnpro,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -838,7 +688,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Imunit,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -848,7 +697,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Lev,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -858,7 +706,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Mblock,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -868,7 +715,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Mtree,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -878,7 +724,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Lsline,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -888,7 +733,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Rkco,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -898,7 +742,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaScl,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -908,7 +751,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaSgn,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -918,7 +760,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaDer,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -928,7 +769,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaInt,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -938,7 +778,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaNoro,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -948,7 +787,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaNors,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -958,7 +796,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaPlu,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -968,7 +805,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaDiu,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -978,7 +814,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaDmu,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -988,7 +823,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaCliw,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -998,7 +832,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaCqlc,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1008,7 +841,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaArea,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1018,7 +850,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaPew,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1028,7 +859,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaPee,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1038,7 +868,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaPea,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1048,7 +877,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaPep,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1058,7 +886,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaEst,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1068,7 +895,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaEpsm,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1078,7 +904,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Epsmin,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1088,7 +913,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaFset,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1098,7 +922,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaFilt,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1108,7 +931,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaNotw,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1118,7 +940,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaFlo,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1128,7 +949,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::CdFlo,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1138,7 +958,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaGmd,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1148,7 +967,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaNow,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1158,7 +976,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Cdf2,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1168,7 +985,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Cdnf,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1178,7 +994,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Cdnfda,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1188,7 +1003,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Cdnfds,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1198,7 +1012,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaRan,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1208,7 +1021,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::DaCode,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1219,7 +1031,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Sleepm,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1229,7 +1040,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Argget,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1239,7 +1049,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Memdpv,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1249,7 +1058,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Memfre,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1258,7 +1066,6 @@ impl FromRule for Statement {
                 .context("...while building MEMALL statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Memall,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1267,7 +1074,6 @@ impl FromRule for Statement {
                 .context("...while building MEMWRT statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Memwrt,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1276,7 +1082,6 @@ impl FromRule for Statement {
                 .context("...while building LTRUE statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Ltrue,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1285,7 +1090,6 @@ impl FromRule for Statement {
                 .context("...while building LFALSE statement!")
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Lfalse,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1296,7 +1100,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Readm,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })
@@ -1306,7 +1109,6 @@ impl FromRule for Statement {
                 .with_location(&loc)
                 .map(|opt| {
                     opt.map(|stmt| Statement {
-                        enum_variant: StatementEnum::Writem,
                         inner: Box::new(stmt),
                         source_location: loc.clone(),
                     })

--- a/rosy/src/resolve.rs
+++ b/rosy/src/resolve.rs
@@ -115,8 +115,8 @@ pub enum ExprRecipe {
         left: Box<ExprRecipe>,
         right: Box<ExprRecipe>,
     },
-    /// An n-ary concat of sub-recipes.
-    Concat(Vec<ExprRecipe>),
+    /// A binary concat of two sub-recipes.
+    Concat(Box<ExprRecipe>, Box<ExprRecipe>),
     /// Any type-preserving intrinsic (sin, cos, tan, exp, log, sqrt, etc.) — output type equals input type.
     TypePreserving(Box<ExprRecipe>),
     /// REAL intrinsic — result depends on input type (RE/CM->RE, DA->DA).
@@ -725,18 +725,11 @@ impl TypeResolver {
                     )
                 })
             }
-            ExprRecipe::Concat(recipes) => {
-                let mut iter = recipes.iter();
-                let first = iter
-                    .next()
-                    .ok_or_else(|| anyhow!("Empty concat expression"))?;
-                let mut result = self.evaluate_recipe(first)?;
-                for r in iter {
-                    let t = self.evaluate_recipe(r)?;
-                    result = crate::rosy_lib::operators::concat::get_return_type(&result, &t)
-                        .ok_or_else(|| anyhow!("No concat rule for {} & {}", result, t))?;
-                }
-                Ok(result)
+            ExprRecipe::Concat(left, right) => {
+                let left_type = self.evaluate_recipe(left)?;
+                let right_type = self.evaluate_recipe(right)?;
+                crate::rosy_lib::operators::concat::get_return_type(&left_type, &right_type)
+                    .ok_or_else(|| anyhow!("No concat rule for {} & {}", left_type, right_type))
             }
             ExprRecipe::TypePreserving(inner) => self.evaluate_recipe(inner),
             ExprRecipe::RealFn(inner) => {

--- a/rosy/src/transpile.rs
+++ b/rosy/src/transpile.rs
@@ -22,7 +22,7 @@
 //! breadcrumbs for error diagnostics.
 
 use crate::{
-    program::{expressions::Expr, statements::SourceLocation},
+    program::statements::SourceLocation,
     resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot},
     rosy_lib::RosyType,
 };
@@ -47,11 +47,6 @@ pub enum TypeHydrationResult {
 pub enum ExprFunctionCallResult {
     HasFunctionCalls { result: Result<()> },
     NoFunctionCalls,
-}
-
-pub enum ConcatExtensionResult {
-    Extended,
-    NotAConcatExpr,
 }
 
 pub trait TranspileableStatement: Transpile + Send + Sync {
@@ -86,7 +81,6 @@ pub trait TranspileableExpr: Transpile + Send + Sync {
         ctx: &ScopeContext,
         deps: &mut HashSet<TypeSlot>,
     ) -> ExprRecipe;
-    fn extend_concat(&mut self, right: Expr) -> ConcatExtensionResult;
 }
 pub trait Transpile: std::fmt::Debug {
     fn transpile(


### PR DESCRIPTION
## Summary

Closes #69

- **Removed `StatementEnum`** (~100 variants) and `enum_variant` field from `Statement` — was set on every construction but never read anywhere
- **Removed `ExprEnum`** (~70 variants), `enum_variant` field from `Expr`, and unused `PartialEq` impl — only read in 2 places, both eliminable
- **Removed `extend_concat`** from the `TranspileableExpr` trait and `ConcatExtensionResult` enum — forced boilerplate default impls in all 70+ expression types
- **Made `ConcatExpr` a standard binary operator** (`left`/`right`) instead of n-ary (`terms: Vec<Expr>`), consistent with every other operator
- **Removed `PartialEq` derives** from 68 expression structs that were only derivable via `ExprEnum`

Net result: **-726 lines** of boilerplate. Every new expression/statement type no longer needs an enum variant or `extend_concat` stub.

## Test plan

- [x] `cargo build` — 0 errors, 0 warnings
- [x] `cargo test` — 9/9 tests pass
- [x] Concat test example produces correct output
- [x] `complex_nesting.rosy` (339-line stress test) passes, including chained `&` operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)