### PR TITLE
fix: show LSP inlay hint for untyped variables defaulting to RE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/examples/basic.rosy
+++ b/examples/basic.rosy
@@ -11,9 +11,11 @@ BEGIN;
     PROCEDURE PRINTSEVENNUMS;
         VARIABLE (VE) X;
         VARIABLE (VE) Y;
+        VARIABLE Z;
         Y := Y & 8;
         X := (0 + 1) & 2 & 3 & 4 & 5 & 6 & 7 & Y;
         WRITE 6 ST(X);
+        WRITE 6 ST(Z) ' <- Defaults to RE';
     ENDPROCEDURE;
 
     {Procedure to print a complex number}
@@ -32,7 +34,7 @@ BEGIN;
         X := 3;
         Y := 4;
         WRITE 6 "Summation of 3 and 4: " ST(ADDTWONUMS(X,Y));
-        
+
         PRINTSEVENNUMS;
         PRINTACOMPLEXNUM;
 
@@ -40,7 +42,7 @@ BEGIN;
             WRITE 6 ST(I);
         ENDLOOP;
     ENDPROCEDURE;
-    
+
     {Call the main procedure}
     RUN;
 END;

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "0.33.1"
+version = "0.33.2"
 edition = "2024"
 
 [lib]

--- a/rosy/src/resolve.rs
+++ b/rosy/src/resolve.rs
@@ -417,7 +417,10 @@ impl TypeResolver {
                     let node = self.nodes.get_mut(&slot).unwrap();
                     let default_type = RosyType::RE();
                     node.resolved = Some(default_type.clone());
-                    node.rule = ResolutionRule::Explicit(default_type);
+                    node.rule = ResolutionRule::InferredFrom {
+                        recipe: ExprRecipe::Literal(default_type),
+                        reason: "untyped variables default to RE".to_string(),
+                    };
                     warned_slots.insert(slot.clone());
                     resolved_count += 1;
                     continue;


### PR DESCRIPTION
## Summary
- Untyped variables (`VARIABLE Z;`) were incorrectly marked as `ResolutionRule::Explicit(RE)` by the type resolver, causing `extract_inlay_hint` to skip them (it filters out explicit types since the user already wrote them)
- Changed to `ResolutionRule::InferredFrom` with reason "untyped variables default to RE", so the LSP now shows the `(RE)` inlay hint with a hover explaining the default
- Updated `examples/basic.rosy` to include an untyped variable example

## Test plan
- [x] `cargo test` — all 9 tests pass
- [ ] Open `examples/basic.rosy` in editor with Rosy LSP, verify `VARIABLE Z;` shows `(RE)` inlay hint
- [ ] Hover over the hint to confirm it says "untyped variables default to RE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)