### PR TITLE
fix: variable shadowing, OPENF 'unknown' semantics, auto-growing indexed assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "0.34.1"
+version = "0.35.0"
 edition = "2024"
 
 [lib]

--- a/rosy/src/program/statements/core/var_decl/mod.rs
+++ b/rosy/src/program/statements/core/var_decl/mod.rs
@@ -310,24 +310,28 @@ impl Transpile for VarDeclStatement {
             ))]
         })?;
 
-        // Insert the declaration, but check it doesn't already exist
-        if matches!(
-            context.variables.insert(
-                self.data.name.clone(),
-                ScopedVariableData {
-                    scope: VariableScope::Local,
-                    data: VariableData {
-                        name: self.data.name.clone(),
-                        r#type: resolved_type.clone()
-                    }
-                }
-            ),
-            Some(_)
-        ) {
-            return Err(vec![anyhow!(
-                "Variable '{}' is already defined in this scope!",
-                self.data.name
-            )]);
+        // Insert the declaration. A previous entry whose scope is `Higher`
+        // came from an enclosing function/procedure — shadowing it locally
+        // is allowed, just like in most lexically-scoped languages. A
+        // previous `Local` or `Arg` entry is a true re-declaration in this
+        // very scope and is still rejected.
+        let previous = context.variables.insert(
+            self.data.name.clone(),
+            ScopedVariableData {
+                scope: VariableScope::Local,
+                data: VariableData {
+                    name: self.data.name.clone(),
+                    r#type: resolved_type.clone(),
+                },
+            },
+        );
+        if let Some(prev) = previous {
+            if prev.scope != VariableScope::Higher {
+                return Err(vec![anyhow!(
+                    "Variable '{}' is already defined in this scope!",
+                    self.data.name
+                )]);
+            }
         }
 
         let data_output = self.data.transpile(context)?;

--- a/rosy/src/rosy_lib/core/file_io.rs
+++ b/rosy/src/rosy_lib/core/file_io.rs
@@ -35,10 +35,10 @@ fn ensure_registry() {
 /// - `unit`: unit number (integer)
 /// - `filename`: path to the file
 /// - `status`: Fortran-style status string:
-///   - `'unknown'`: create if doesn't exist, truncate if does
+///   - `'unknown'`: read+write; open existing as-is, or create empty if it doesn't exist
 ///   - `'old'`: open existing file for reading
-///   - `'new'`: create new file, error if exists
-///   - `'replace'`: create or replace file
+///   - `'new'`: create new file for writing, error if it already exists
+///   - `'replace'`: create or truncate, then open for writing
 pub fn rosy_openf(unit: f64, filename: &str, status: &str) -> Result<()> {
     open_file_impl(unit, filename, status, false)
 }
@@ -62,15 +62,37 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
     }
 
     match status_lower.as_str() {
-        "unknown" | "replace" => {
-            // Create or truncate for writing
+        "unknown" => {
+            // Fortran-style 'UNKNOWN': open for read+write. Existing file
+            // contents are preserved (no truncation); a new file is created
+            // empty if needed. The reader and writer share the same OS file
+            // offset via `try_clone`.
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(filename)
+                .with_context(|| format!("Failed to open file '{}' (unit {})", filename, unit_num))?;
+
+            let read_handle = file.try_clone()
+                .with_context(|| format!("Failed to clone file handle for '{}' (unit {})", filename, unit_num))?;
+
+            registry.insert(unit_num, FileHandle {
+                reader: Some(BufReader::new(read_handle)),
+                writer: Some(BufWriter::new(file)),
+                path: filename.to_string(),
+                is_binary,
+            });
+        }
+        "replace" => {
+            // Always create or truncate, then open for writing.
             let file = OpenOptions::new()
                 .write(true)
                 .create(true)
                 .truncate(true)
                 .open(filename)
                 .with_context(|| format!("Failed to open file '{}' for writing (unit {})", filename, unit_num))?;
-            
+
             registry.insert(unit_num, FileHandle {
                 reader: None,
                 writer: Some(BufWriter::new(file)),
@@ -82,7 +104,7 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
             // Open existing for reading
             let file = File::open(filename)
                 .with_context(|| format!("Failed to open existing file '{}' for reading (unit {})", filename, unit_num))?;
-            
+
             registry.insert(unit_num, FileHandle {
                 reader: Some(BufReader::new(file)),
                 writer: None,
@@ -96,7 +118,7 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
                 .create_new(true)
                 .open(filename)
                 .with_context(|| format!("Failed to create new file '{}' (unit {}). File may already exist.", filename, unit_num))?;
-            
+
             registry.insert(unit_num, FileHandle {
                 reader: None,
                 writer: Some(BufWriter::new(file)),

--- a/rosy/src/rosy_lib/mod.rs
+++ b/rosy/src/rosy_lib/mod.rs
@@ -54,16 +54,24 @@ pub fn rosy_get<'a, T, C: AsRef<[T]>>(container: &'a C, one_based: f64, var_name
     })
 }
 
-/// Mutable 1-based index. Returns `&mut T`.
-/// Same rounding and bounds checking as [`rosy_get`].
+/// Mutable 1-based index for assignment. Returns `&mut T`.
+///
+/// Unlike the read-side [`rosy_get`], this auto-grows the vector to fit
+/// the requested 1-based index, padding new slots with `T::default()`.
+/// This matches COSY semantics where `VARIABLE FOO ;` followed by
+/// `FOO(1) := X` allocates slot 1 lazily.
+///
+/// Indices ≤ 0 still panic — those are programmer errors, not omissions.
 #[inline(always)]
-pub fn rosy_get_mut<'a, T, C: AsMut<[T]>>(container: &'a mut C, one_based: f64, var_name: &str) -> &'a mut T {
-    let slice = container.as_mut();
-    let len = slice.len();
+pub fn rosy_get_mut<'a, T: Default>(container: &'a mut Vec<T>, one_based: f64, var_name: &str) -> &'a mut T {
     let idx = one_based.round() as usize;
-    slice.get_mut(idx.wrapping_sub(1)).unwrap_or_else(|| {
-        panic!("Index {} into '{}' is out of bounds (1-{})", idx, var_name, len)
-    })
+    if idx == 0 {
+        panic!("Index 0 into '{}' is out of bounds — Rosy uses 1-based indexing", var_name);
+    }
+    if idx > container.len() {
+        container.resize_with(idx, T::default);
+    }
+    &mut container[idx - 1]
 }
 
 pub type RE = f64;

--- a/rosy/src/rosy_lib/taylor/da.rs
+++ b/rosy/src/rosy_lib/taylor/da.rs
@@ -211,6 +211,14 @@ impl<T: DACoefficient> PartialEq for DA<T> {
 // Basic methods
 // ============================================================================
 
+// Default delegates to zero(); requires the Taylor runtime to be initialized
+// (i.e., DAINI must have been called) before any DA value is constructed.
+impl<T: DACoefficient> Default for DA<T> {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
 impl<T: DACoefficient> DA<T> {
     pub fn zero() -> Self {
         let rt = get_runtime().expect("Taylor system not initialized (call OV first)");


### PR DESCRIPTION
## Summary

Three independent fixes uncovered while triaging `DAtest.rosy`:

1. **Nested-FUNCTION variable shadowing** — Rosy was rejecting `VARIABLE I` inside an inner `FUNCTION` whenever an outer `PROCEDURE` already declared `I`, even though the outer one is in a different lexical scope. The check was matching on _any_ pre-existing entry, including those marked `Higher` (inherited from a parent scope).
2. **`OPENF status='unknown'`** — Was opening write-only with truncation. Fortran/COSY's `'unknown'` is "open existing as-is, or create new" with read+write access. Reading from a unit opened that way then errored with "File on unit N is not open for reading."
3. **`FOO(N) := X` on an unsized variable** — Variables declared without explicit dimensions (`VARIABLE COORD ;` then `COORD(1) := X`) were initialized as a zero-length `Vec` and panicked on first write. COSY's "VARIABLE is a memory pool" semantic expects auto-allocation on indexed write.

## Changes

| File | Change |
|------|--------|
| `rosy/src/program/statements/core/var_decl/mod.rs` | Allow shadowing when previous scope is `Higher`; still reject `Local`/`Arg` collisions. |
| `rosy/src/rosy_lib/core/file_io.rs` | Split `'unknown'` from `'replace'`. `'unknown'` now opens read+write (no truncate) with both `BufReader`/`BufWriter` via `try_clone`. `'replace'` keeps previous truncate behavior. |
| `rosy/src/rosy_lib/mod.rs` | `rosy_get_mut<T: Default>(&mut Vec<T>, …)` auto-grows with `resize_with(idx, T::default)`. Index 0 still panics. Reads (`rosy_get`) still bounds-check. |
| `rosy/src/rosy_lib/taylor/da.rs` | `impl<T: DACoefficient> Default for DA<T>` delegating to `Self::zero()` so `DA`/`CD` slots auto-initialize cleanly. |
| `rosy/Cargo.toml` | Bump `0.34.1` → `0.35.0` (minor: language-semantic changes). |

## Test plan

- [x] All 166 unit tests pass: `cargo run --release --bin rosy -- test --parallel 8` → `166 passed, 0 failed (328.2s)`
- [x] Issue 1 reproducer (`DAtest_issue1_shadowed_vars.rosy`) compiles & runs, prints the expected constant vector.
- [x] Issue 2 reproducer (`DAtest_issue2_read_unknown_file.rosy`) writes 5 lines via `'unknown'`, reopens with `'unknown'`, reads them back successfully.
- [x] Issue 3 reproducer (`DAtest_issue3_indexed_da_assignment.rosy`) runs, prints `COORD(1) = 1.5` and `MAP1(1)` as a DA with coefficient 1.0.
- [x] All root-level `examples/*.rosy` re-tested. 17/22 pass; the 5 failures (`briefdemo_nondyn`, `ploop`, `test_lsline_n1/_vertical`, `test_writem_readm`) **pre-existed on `master`** — verified by stashing this branch and re-running.

## Notes

- **Auto-grow is asymmetric**: only mutable indexing (`rosy_get_mut`) auto-grows; reads still error on out-of-bounds. This matches COSY's "writing allocates a slot, reading an unallocated slot is a bug" model.
- **`'unknown'` reader/writer share an OS offset** via `File::try_clone`. Sequential write-then-close-then-reopen-and-read (the typical COSY pattern) works. Mixed read/write within one open without `REWF` between would produce surprising offsets — same caveat Fortran has.
- `DA::default()` requires the Taylor runtime to be initialized (i.e., `DAINI` must run first). Same constraint as `DA::zero()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)