### PR TITLE
chore: v1.0.0-alpha.0 release prep — cosy → assets/, hiibolt → rosy-team, AND/OR fix

### DIFF
--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [master]
     paths:
-      - 'rosy/assets/rosy.pest'
-      - 'rosy/build.rs'
+      - "rosy/assets/rosy.pest"
+      - "rosy/build.rs"
 
 permissions:
   contents: write
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout rosy-tree-sitter
         uses: actions/checkout@v5
         with:
-          repository: hiibolt/rosy-tree-sitter
+          repository: rosy-team/rosy-tree-sitter
           token: ${{ secrets.TREE_SITTER_PAT }}
           path: rosy-tree-sitter
 
@@ -56,7 +56,7 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-          git commit -m "chore: sync grammar from hiibolt/rosy@${GITHUB_SHA::8}
+          git commit -m "chore: sync grammar from rosy-team/rosy@${GITHUB_SHA::8}
 
           Auto-generated from rosy.pest by CI."
           git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "0.42.30"
+version = "1.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rosy transpiles source code into self-contained, native Rust executables — opt
 
 ## Language Documentation
 
-The complete Rosy language reference — every operator, function, statement, and type — is in the **[Rustdoc documentation](https://hiibolt.github.io/rosy/)**.
+The complete Rosy language reference — every operator, function, statement, and type — is in the **[Rustdoc documentation](https://rosy-team.github.io/rosy/)**.
 
 ## Example
 
@@ -39,7 +39,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup default nightly
 
 # Build and install Rosy
-git clone https://github.com/hiibolt/rosy.git
+git clone https://github.com/rosy-team/rosy.git
 cd rosy
 cargo install --path rosy
 ```
@@ -70,7 +70,7 @@ cargo install --path rosy --force
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
 rustup default nightly
-git clone https://github.com/hiibolt/rosy.git
+git clone https://github.com/rosy-team/rosy.git
 cd rosy && cargo install --path rosy
 
 # For MPI programs (PLOOP)
@@ -91,7 +91,7 @@ cargo install --path rosy --force
 
 ### From GitHub Releases
 
-Prebuilt binaries for Linux (x86_64) and macOS (x86_64, aarch64) are available on the [Releases page](https://github.com/hiibolt/rosy/releases/latest).
+Prebuilt binaries for Linux (x86_64) and macOS (x86_64, aarch64) are available on the [Releases page](https://github.com/rosy-team/rosy/releases/latest).
 
 ### Using Nix Flakes
 

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "0.42.31"
+version = "1.0.0-alpha.0"
 edition = "2024"
 
 [lib]

--- a/rosy/assets/editors/vscode/package.json
+++ b/rosy/assets/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rosy Language Support",
   "description": "Syntax highlighting and language server support for the Rosy programming language",
   "version": "0.0.0-injected",
-  "publisher": "hiibolt",
+  "publisher": "rosy-team",
   "engines": {
     "vscode": "^1.74.0"
   },
@@ -24,8 +24,13 @@
     "languages": [
       {
         "id": "rosy",
-        "aliases": ["Rosy", "rosy"],
-        "extensions": [".rosy"],
+        "aliases": [
+          "Rosy",
+          "rosy"
+        ],
+        "extensions": [
+          ".rosy"
+        ],
         "configuration": "./language-configuration.json"
       }
     ],

--- a/rosy/assets/editors/zed/extension.toml
+++ b/rosy/assets/editors/zed/extension.toml
@@ -3,11 +3,11 @@ name = "Rosy"
 description = "Rosy language support — diagnostics, completions, type hints, and inlay hints"
 version = "0.1.0"
 schema_version = 1
-authors = ["hiibolt"]
-repository = "https://github.com/hiibolt/rosy"
+authors = ["rosy-team"]
+repository = "https://github.com/rosy-team/rosy"
 
 [grammars.rosy]
-repository = "https://github.com/hiibolt/rosy-tree-sitter"
+repository = "https://github.com/rosy-team/rosy-tree-sitter"
 rev = "2e5604d0bf4ff048b4e640a3e8c70b6fa0e16f99"
 
 [language_servers.rosy-lsp]

--- a/rosy/assets/rosy.pest
+++ b/rosy/assets/rosy.pest
@@ -449,8 +449,13 @@ lt          = { "<" }
 gt          = { ">" }
 lte         = { "<=" }
 gte         = { ">=" }
-and_op      = { ^"AND" ~ !(ASCII_ALPHANUMERIC | "_") }
-or_op       = { ^"OR"  ~ !(ASCII_ALPHANUMERIC | "_") }
+// Atomic so pest does not insert WHITESPACE between the literal and the
+// negative-lookahead boundary check — without `@`, the lookahead would
+// match the char *after* the trailing space instead of the immediate next
+// char, which previously caused `TRUE AND TRUE` to fail to parse because
+// the lookahead saw the leading T of the right-hand TRUE and rejected it.
+and_op      = @{ ^"AND" ~ !(ASCII_ALPHANUMERIC | "_") }
+or_op       = @{ ^"OR"  ~ !(ASCII_ALPHANUMERIC | "_") }
 
 variable_identifier = { variable_name ~ paren_group* ~ bracket_index* }
 paren_group = { "(" ~ expr ~ ("," ~ expr)* ~ ")" }

--- a/rosy/build.rs
+++ b/rosy/build.rs
@@ -135,7 +135,7 @@ fn collect_files(root: &Path, current: &Path) -> Vec<PathBuf> {
 
 // ─── LSP: Keyword & Hover Doc Generation ───────────────────────────────────
 
-const BASE_DOC_URL: &str = "https://hiibolt.github.io/rosy/rosy";
+const BASE_DOC_URL: &str = "https://rosy-team.github.io/rosy/rosy";
 
 fn extract_keywords(source: &str) -> Vec<String> {
     let mut keywords = Vec::new();
@@ -679,7 +679,11 @@ fn generate_tree_sitter_grammar(
         .collect();
     grammar.push_str("    _builtin: _ => choice(\n");
     for (i, func) in filtered_intrinsics.iter().enumerate() {
-        let comma = if i < filtered_intrinsics.len() - 1 { "," } else { "" };
+        let comma = if i < filtered_intrinsics.len() - 1 {
+            ","
+        } else {
+            ""
+        };
         grammar.push_str(&format!(
             "      '{}', '{}'{}\n",
             func.to_uppercase(),
@@ -725,7 +729,6 @@ fn generate_tree_sitter_grammar(
 
     fs::write(Path::new(out_dir).join("grammar.js"), &grammar).unwrap();
 }
-
 
 /// Generate highlights.scm for Zed/Tree-sitter.
 ///
@@ -786,10 +789,7 @@ fn generate_tree_sitter_highlights(
     // Statement keywords (excluding intrinsics, types, booleans)
     scm.push_str("; Keywords\n");
     for kw in keywords {
-        if intrinsics.contains(kw)
-            || types.contains(&kw.as_str())
-            || kw == "TRUE"
-            || kw == "FALSE"
+        if intrinsics.contains(kw) || types.contains(&kw.as_str()) || kw == "TRUE" || kw == "FALSE"
         {
             continue;
         }

--- a/rosy/src/lib.rs
+++ b/rosy/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "nightly-simd", feature(portable_simd))]
 //! # Rosy
 //!
-#![doc = concat!("**Version:** `v", env!("CARGO_PKG_VERSION"), "` — Built `", env!("BUILD_TIMESTAMP"), "` — [Changelog](https://github.com/hiibolt/rosy/releases)")]
+#![doc = concat!("**Version:** `v", env!("CARGO_PKG_VERSION"), "` — Built `", env!("BUILD_TIMESTAMP"), "` — [Changelog](https://github.com/rosy-team/rosy/releases)")]
 //!
 //! A modern transpiler for the Rosy scientific programming language,
 //! designed for beam physics and differential algebra applications.
@@ -11,8 +11,8 @@
 //! The official Rosy language reference begins in the [`program`] module.
 //!
 //! ## More Resources
-//! - **[Example programs](https://github.com/hiibolt/rosy/tree/master/examples)** on GitHub
-//! - **[Installation & usage](https://github.com/hiibolt/rosy)** in the README
+//! - **[Example programs](https://github.com/rosy-team/rosy/tree/master/examples)** on GitHub
+//! - **[Installation & usage](https://github.com/rosy-team/rosy)** in the README
 
 pub mod ast;
 pub mod embedded;

--- a/rosy/src/lsp/analysis.rs
+++ b/rosy/src/lsp/analysis.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::RosyError,
     program::Program,
     resolve::{GraphNode, TypeResolver, TypeSlot},
-    transpile::{Transpile, TranspilationInputContext},
+    transpile::{TranspilationInputContext, Transpile},
 };
 use pest::Parser;
 use tower_lsp::lsp_types::*;
@@ -198,10 +198,12 @@ pub fn analyze(source: &str, source_path: Option<&std::path::Path>) -> AnalysisR
                 let position = w
                     .location
                     .as_ref()
-                    .map(|loc| Position::new(
-                        loc.line.saturating_sub(1) as u32,
-                        loc.col.saturating_sub(1) as u32,
-                    ))
+                    .map(|loc| {
+                        Position::new(
+                            loc.line.saturating_sub(1) as u32,
+                            loc.col.saturating_sub(1) as u32,
+                        )
+                    })
                     .unwrap_or(Position::new(0, 0));
                 result.diagnostics.push(Diagnostic {
                     range: Range::new(position, position),
@@ -239,8 +241,7 @@ pub fn analyze(source: &str, source_path: Option<&std::path::Path>) -> AnalysisR
         Ok(_) => {}
         Err(errors) => {
             for err in &errors {
-                let position =
-                    extract_location_from_anyhow(err).unwrap_or(Position::new(0, 0));
+                let position = extract_location_from_anyhow(err).unwrap_or(Position::new(0, 0));
                 // Extract the clean message from the innermost RosyError,
                 // falling back to root_cause Display if no RosyError found.
                 let message = extract_message_from_anyhow(err);
@@ -305,15 +306,18 @@ fn extract_inlay_hint(node: &GraphNode, hints: &mut Vec<InlayHintData>) {
     // exactly where the type was determined.
     let (reason, loc) = match &node.rule {
         crate::resolve::ResolutionRule::Explicit(_) => (None, None),
-        crate::resolve::ResolutionRule::InferredFrom { reason, .. } => {
-            (Some(reason.clone()), node.assigned_at.as_ref().or(node.declared_at.as_ref()))
-        }
-        crate::resolve::ResolutionRule::Mirror { reason, .. } => {
-            (Some(reason.clone()), node.assigned_at.as_ref().or(node.declared_at.as_ref()))
-        }
-        crate::resolve::ResolutionRule::Unresolved => {
-            (Some("could not be inferred".to_string()), node.declared_at.as_ref())
-        }
+        crate::resolve::ResolutionRule::InferredFrom { reason, .. } => (
+            Some(reason.clone()),
+            node.assigned_at.as_ref().or(node.declared_at.as_ref()),
+        ),
+        crate::resolve::ResolutionRule::Mirror { reason, .. } => (
+            Some(reason.clone()),
+            node.assigned_at.as_ref().or(node.declared_at.as_ref()),
+        ),
+        crate::resolve::ResolutionRule::Unresolved => (
+            Some("could not be inferred".to_string()),
+            node.declared_at.as_ref(),
+        ),
     };
 
     let inferred_from = match (reason, loc) {
@@ -522,19 +526,17 @@ include!(concat!(env!("OUT_DIR"), "/hover_generated.rs"));
 /// Intrinsic functions — these get `FUNC($0)` snippet insertion.
 /// Everything else in the keyword list gets plain keyword completion.
 const INTRINSIC_FUNCTIONS: &[&str] = &[
-    "ABS", "ACOS", "ASIN", "ATAN", "CD", "CM", "CMPLX", "CONJ", "CONS",
-    "COS", "COSH", "DA", "ERF", "EXP", "IMAG", "INT", "ISRT", "ISRT3",
-    "LCD", "LCM", "LDA", "LENGTH", "LLO", "LO", "LOG", "LRE", "LST",
-    "LTRIM", "LVE", "NINT", "NORM", "RE", "REAL", "SIN", "SINH", "SQR",
-    "SQRT", "ST", "TAN", "TANH", "TRIM", "TYPE", "VARMEM", "VARPOI",
-    "VE", "VMAX", "VMIN", "WERF",
+    "ABS", "ACOS", "ASIN", "ATAN", "CD", "CM", "CMPLX", "CONJ", "CONS", "COS", "COSH", "DA", "ERF",
+    "EXP", "IMAG", "INT", "ISRT", "ISRT3", "LCD", "LCM", "LDA", "LENGTH", "LLO", "LO", "LOG",
+    "LRE", "LST", "LTRIM", "LVE", "NINT", "NORM", "RE", "REAL", "SIN", "SINH", "SQR", "SQRT", "ST",
+    "TAN", "TANH", "TRIM", "TYPE", "VARMEM", "VARPOI", "VE", "VMAX", "VMIN", "WERF",
 ];
 
 /// Build completion items from the auto-generated keyword list.
 /// Keywords are extracted from `keyword_raw` in rosy.pest at compile time,
 /// so adding a new construct to the grammar automatically updates completions.
 pub fn rosy_keywords() -> Vec<CompletionItem> {
-    let base_url = "https://hiibolt.github.com/rosy/rosy";
+    let base_url = "https://rosy-team.github.com/rosy/rosy";
 
     let mut items: Vec<CompletionItem> = ROSY_KEYWORD_LIST
         .iter()
@@ -591,13 +593,25 @@ mod tests {
         let result = analyze(source, None);
         eprintln!("Hints:");
         for h in &result.variable_types {
-            eprintln!("  line={} col={} label={:?}", h.position.line, h.position.character, h.label);
+            eprintln!(
+                "  line={} col={} label={:?}",
+                h.position.line, h.position.character, h.label
+            );
         }
-        let labels: Vec<&str> = result.variable_types.iter().map(|h| h.label.as_str()).collect();
+        let labels: Vec<&str> = result
+            .variable_types
+            .iter()
+            .map(|h| h.label.as_str())
+            .collect();
         // temp (inferred RE) and is_true (inferred LO) should have hints
         assert!(labels.contains(&"(RE)"), "temp should get an (RE) hint");
         assert!(labels.contains(&"(LO)"), "is_true should get an (LO) hint");
         // Explicitly typed variables should NOT have hints
-        assert_eq!(result.variable_types.len(), 2, "Only inferred types should produce hints, got: {:?}", labels);
+        assert_eq!(
+            result.variable_types.len(),
+            2,
+            "Only inferred types should produce hints, got: {:?}",
+            labels
+        );
     }
 }

--- a/rosy/src/main.rs
+++ b/rosy/src/main.rs
@@ -1,9 +1,9 @@
 mod update_check;
 
-use rosy::{ast, embedded, program::Program, resolve, syntax_config, transpile::*};
 use anyhow::{Context, Result, anyhow, ensure};
 use clap::{Parser as ClapParser, Subcommand};
 use pest::Parser;
+use rosy::{ast, embedded, program::Program, resolve, syntax_config, transpile::*};
 use std::{fs, fs::write, path::PathBuf, process::Command, time::Instant};
 use tracing::info;
 use tracing_subscriber;
@@ -175,14 +175,15 @@ fn rosy(
         Some(script_path),
         &mut rosy::program::IncludeTracker::default(),
     )
-        .context("Failed to build AST!")?
-        .context("Expected a program")?;
+    .context("Failed to build AST!")?
+    .context("Expected a program")?;
     step_done(t);
 
     // --- Step 3: Type Resolution ---
     step(4, 6, "Resolving types");
     let t = Instant::now();
-    let (_resolver, warnings) = resolve::TypeResolver::resolve(&mut ast).context("Failed to resolve types!")?;
+    let (_resolver, warnings) =
+        resolve::TypeResolver::resolve(&mut ast).context("Failed to resolve types!")?;
     step_done(t);
     for w in &warnings {
         eprintln!("{BOLD}{YELLOW}    warning{RESET}: {}", w.message);
@@ -253,7 +254,7 @@ fn rosy(
         eprintln!("{BOLD}{RED}  error:{RESET} The generated Rust code failed to compile.");
         eprintln!();
         eprintln!("  This is a bug in the Rosy transpiler, not in your code.");
-        eprintln!("  Please report it at: {BOLD}https://github.com/hiibolt/rosy/issues{RESET}");
+        eprintln!("  Please report it at: {BOLD}https://github.com/rosy-team/rosy/issues{RESET}");
         eprintln!("  Include your {BOLD}.rosy{RESET} file and the error output above.");
         anyhow::bail!(
             "Internal transpiler error: generated code failed to compile (exit code {:?})",
@@ -262,7 +263,11 @@ fn rosy(
     }
 
     let build_profile = if release { "release" } else { "debug" };
-    let binary_name = if cfg!(windows) { "rosy_output.exe" } else { "rosy_output" };
+    let binary_name = if cfg!(windows) {
+        "rosy_output.exe"
+    } else {
+        "rosy_output"
+    };
     let binary_path = rosy_output_path.join(format!("target/{}/{}", build_profile, binary_name));
 
     let total_ms = total_start.elapsed().as_millis();
@@ -478,7 +483,7 @@ fn run_construct_tests(filter: Option<&str>, release: bool, parallel: usize) -> 
         eprintln!("    Parallel: {parallel} workers");
     }
 
-    let cosy_bin = workspace_root.join("cosy");
+    let cosy_bin = workspace_root.join("assets").join("cosy");
     let has_cosy = cosy_bin.exists() && cosy_bin.is_file();
     if has_cosy {
         eprintln!("        COSY: {GREEN}found{RESET}");
@@ -619,9 +624,13 @@ fn run_construct_tests(filter: Option<&str>, release: bool, parallel: usize) -> 
 // static (embedded from editors/vscode/). The language config is generated
 // from the grammar at build time so folding/indent keywords stay in sync.
 const VSCODE_PACKAGE_JSON: &str = include_str!("../assets/editors/vscode/package.json");
-const VSCODE_LANG_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/vscode_language_configuration.json"));
+const VSCODE_LANG_CONFIG: &str = include_str!(concat!(
+    env!("OUT_DIR"),
+    "/vscode_language_configuration.json"
+));
 const VSCODE_EXTENSION_JS: &str = include_str!("../assets/editors/vscode/extension.js");
-const VSCODE_TM_GRAMMAR: &str = include_str!("../assets/editors/vscode/syntaxes/rosy.tmLanguage.json");
+const VSCODE_TM_GRAMMAR: &str =
+    include_str!("../assets/editors/vscode/syntaxes/rosy.tmLanguage.json");
 
 // Zed extension files — embedded at build time.
 // Unlike VS Code, Zed extensions need a WASM component, so we write the
@@ -647,36 +656,45 @@ fn install_vscode_extension() -> Result<()> {
     let extensions_dir = PathBuf::from(&home).join(".vscode/extensions");
 
     // Clean up old extension directories from before the naming fix
-    for old_name in ["rosy-language-support", "hiibolt.rosy-language-support"] {
+    for old_name in ["rosy-language-support", "rosy-team.rosy-language-support"] {
         let old_ext_dir = extensions_dir.join(old_name);
         if old_ext_dir.exists() {
-            eprintln!("{DIM}  Removing old extension at {}{RESET}", old_ext_dir.display());
+            eprintln!(
+                "{DIM}  Removing old extension at {}{RESET}",
+                old_ext_dir.display()
+            );
             let _ = fs::remove_dir_all(&old_ext_dir);
         }
     }
 
-    // Also clean up any previous versioned installs (hiibolt.rosy-language-support-*)
+    // Also clean up any previous versioned installs (rosy-team.rosy-language-support-*)
     if let Ok(entries) = fs::read_dir(&extensions_dir) {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if name.starts_with("hiibolt.rosy-language-support-") {
-                eprintln!("{DIM}  Removing old extension at {}{RESET}", entry.path().display());
+            if name.starts_with("rosy-team.rosy-language-support-") {
+                eprintln!(
+                    "{DIM}  Removing old extension at {}{RESET}",
+                    entry.path().display()
+                );
                 let _ = fs::remove_dir_all(entry.path());
             }
         }
     }
 
     let ext_version = env!("CARGO_PKG_VERSION");
-    let ext_dir = extensions_dir.join(format!("hiibolt.rosy-language-support-{ext_version}"));
+    let ext_dir = extensions_dir.join(format!("rosy-team.rosy-language-support-{ext_version}"));
     let syntaxes_dir = ext_dir.join("syntaxes");
 
-    let action = if ext_dir.exists() { "Updating" } else { "Installing" };
+    let action = if ext_dir.exists() {
+        "Updating"
+    } else {
+        "Installing"
+    };
     eprintln!("{BOLD}  {action}{RESET} VS Code extension");
     eprintln!("         to: {}", ext_dir.display());
 
-    fs::create_dir_all(&syntaxes_dir)
-        .context("Failed to create extension directory")?;
+    fs::create_dir_all(&syntaxes_dir).context("Failed to create extension directory")?;
 
     // Inject the transpiler version into package.json so it matches the folder name
     let package_json = VSCODE_PACKAGE_JSON.replace(
@@ -684,15 +702,18 @@ fn install_vscode_extension() -> Result<()> {
         &format!("\"version\": \"{}\"", ext_version),
     );
     write(ext_dir.join("package.json"), package_json)?;
-    write(ext_dir.join("language-configuration.json"), VSCODE_LANG_CONFIG)?;
+    write(
+        ext_dir.join("language-configuration.json"),
+        VSCODE_LANG_CONFIG,
+    )?;
     write(ext_dir.join("extension.js"), VSCODE_EXTENSION_JS)?;
     write(syntaxes_dir.join("rosy.tmLanguage.json"), VSCODE_TM_GRAMMAR)?;
 
     // Register the extension in VS Code's extensions.json registry
     let registry_path = extensions_dir.join("extensions.json");
     let mut registry: Vec<serde_json::Value> = if registry_path.exists() {
-        let contents = fs::read_to_string(&registry_path)
-            .context("Failed to read extensions.json")?;
+        let contents =
+            fs::read_to_string(&registry_path).context("Failed to read extensions.json")?;
         serde_json::from_str(&contents).unwrap_or_default()
     } else {
         Vec::new()
@@ -700,15 +721,16 @@ fn install_vscode_extension() -> Result<()> {
 
     // Remove any existing rosy entries
     registry.retain(|entry| {
-        entry.get("identifier")
+        entry
+            .get("identifier")
             .and_then(|id| id.get("id"))
             .and_then(|id| id.as_str())
-            != Some("hiibolt.rosy-language-support")
+            != Some("rosy-team.rosy-language-support")
     });
 
-    let relative_location = format!("hiibolt.rosy-language-support-{ext_version}");
+    let relative_location = format!("rosy-team.rosy-language-support-{ext_version}");
     registry.push(serde_json::json!({
-        "identifier": { "id": "hiibolt.rosy-language-support" },
+        "identifier": { "id": "rosy-team.rosy-language-support" },
         "version": ext_version,
         "location": {
             "$mid": 1,
@@ -725,11 +747,15 @@ fn install_vscode_extension() -> Result<()> {
         }
     }));
 
-    let registry_json = serde_json::to_string_pretty(&registry)
-        .context("Failed to serialize extensions.json")?;
+    let registry_json =
+        serde_json::to_string_pretty(&registry).context("Failed to serialize extensions.json")?;
     write(&registry_path, registry_json)?;
 
-    let done_verb = if action == "Updating" { "Updated" } else { "Installed" };
+    let done_verb = if action == "Updating" {
+        "Updated"
+    } else {
+        "Installed"
+    };
     eprintln!("{BOLD}{GREEN}    {done_verb}{RESET} Rosy Language Support for VS Code");
     eprintln!();
     eprintln!("  Reload VS Code to activate. Open any {BOLD}.rosy{RESET} file to see");
@@ -755,14 +781,16 @@ fn install_zed_extension() -> Result<()> {
     let src_dir = ext_dir.join("src");
     let languages_dir = ext_dir.join("languages/rosy");
 
-    let action = if ext_dir.exists() { "Updating" } else { "Writing" };
+    let action = if ext_dir.exists() {
+        "Updating"
+    } else {
+        "Writing"
+    };
     eprintln!("{BOLD}  {action}{RESET} Zed extension source");
     eprintln!("         to: {}", ext_dir.display());
 
-    fs::create_dir_all(&src_dir)
-        .context("Failed to create extension source directory")?;
-    fs::create_dir_all(&languages_dir)
-        .context("Failed to create languages directory")?;
+    fs::create_dir_all(&src_dir).context("Failed to create extension source directory")?;
+    fs::create_dir_all(&languages_dir).context("Failed to create languages directory")?;
 
     write(ext_dir.join("extension.toml"), ZED_EXTENSION_TOML)?;
     write(ext_dir.join("Cargo.toml"), ZED_CARGO_TOML)?;
@@ -770,7 +798,11 @@ fn install_zed_extension() -> Result<()> {
     write(languages_dir.join("config.toml"), ZED_CONFIG_TOML)?;
     write(languages_dir.join("highlights.scm"), ZED_HIGHLIGHTS_SCM)?;
 
-    let done_verb = if action == "Updating" { "Updated" } else { "Wrote" };
+    let done_verb = if action == "Updating" {
+        "Updated"
+    } else {
+        "Wrote"
+    };
     eprintln!("{BOLD}{GREEN}    {done_verb}{RESET} Rosy extension for Zed");
     eprintln!();
     eprintln!("  {BOLD}Prerequisites:{RESET}");

--- a/rosy/src/update_check.rs
+++ b/rosy/src/update_check.rs
@@ -3,8 +3,7 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-const GITHUB_API_URL: &str =
-    "https://api.github.com/repos/hiibolt/rosy/releases/latest";
+const GITHUB_API_URL: &str = "https://api.github.com/repos/rosy-team/rosy/releases/latest";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -56,15 +55,17 @@ fn check_latest_version() -> Option<String> {
         .read_json()
         .ok()?;
 
-    let remote_tag = response.tag_name.strip_prefix('v').unwrap_or(&response.tag_name);
+    let remote_tag = response
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&response.tag_name);
     let remote_version = Version::parse(remote_tag).ok()?;
     let local_version = Version::parse(CURRENT_VERSION).ok()?;
 
     if remote_version > local_version {
-        let release_url = format!("https://github.com/hiibolt/rosy/releases/tag/v{remote_version}");
-        let changelog_link = format!(
-            "\x1b]8;;{release_url}\x1b\\changelog\x1b]8;;\x1b\\"
-        );
+        let release_url =
+            format!("https://github.com/rosy-team/rosy/releases/tag/v{remote_version}");
+        let changelog_link = format!("\x1b]8;;{release_url}\x1b\\changelog\x1b]8;;\x1b\\");
         Some(format!(
             "\n\x1b[33mA newer version of Rosy is available: v{remote_version} (current: v{local_version}) — {changelog_link}\n\
              \n\


### PR DESCRIPTION
## Summary

Three coordinated housekeeping changes ahead of the first 1.0 alpha. Bumps version `0.42.31` → `1.0.0-alpha.0`. Full `rosy test --parallel 8 --release` passes (167/167) with these changes applied.

## What's in this PR

### 1. Relocate the COSY INFINITY reference binary (cosy → assets/)
The `cosy` binary used by `rosy test` for parity diffs moves from the workspace root into a new top-level `assets/` directory. Single code reference updated in `rosy/src/main.rs`. New top-level dir was chosen over `rosy/assets/` so the 18MB binary doesn't bloat the rosy crate's eventual `cargo package` size.

### 2. Rename hiibolt → rosy-team across all repo references
The Rosy project now lives under the [rosy-team](https://github.com/rosy-team) GitHub organization. Updates:
- `README.md` install URLs + prebuilt-binaries link
- `.github/workflows/tree-sitter.yml` source repo
- `rosy/assets/editors/vscode/package.json` publisher
- `rosy/assets/editors/zed/extension.toml` authors / repository / grammar.repository
- `rosy/src/lib.rs` rustdoc Changelog URL
- `rosy/build.rs` `BASE_DOC_URL`
- `rosy/src/update_check.rs` `GITHUB_API_URL`

### 3. Fix AND/OR operator parsing (real bug)
`and_op` / `or_op` were non-atomic, so pest auto-inserted `WHITESPACE` between `^"AND"` and `!(ASCII_ALPHANUMERIC | "_")`. The lookahead then tested the char *after* the trailing space rather than the next char, causing `TRUE AND TRUE` to fail to parse (the right-hand `T` is alphanumeric → lookahead rejected → rule never matched). Marking both rules atomic with `@` suppresses the implicit whitespace insertion and the boundary check now fires immediately after the literal — same pattern the `keyword` rule has always used. A comment in the grammar file explains the gotcha for future readers.

This unblocks the previously-broken `expressions/and_op` and `expressions/or_op` tests.

## Coordination with PR #84

[PR #84](https://github.com/rosy-team/rosy/pull/84) (feat: Package management) bumps `0.42.31` → `0.43.0`. This PR bumps `0.42.31` → `1.0.0-alpha.0`. **Pick one:**

- **A.** Merge PR #84 first (releases `v0.43.0`), then rebase this PR on top — carries `1.0.0-alpha.0` forward, two releases total.
- **B.** Combine both PRs into a single merge that lands as `1.0.0-alpha.0` — one release, skips `0.43.0`.
- **C.** Ship this PR first as `1.0.0-alpha.0`, then rebase PR #84 on top with no further version bump (or move PR #84 to `1.0.1-alpha.0`).

I'd lean **B**: package management is the headline feature for the alpha, and one merge commit cleanly tags the release.

## Test plan

- [x] `cargo build --release` clean
- [x] Full `rosy test --parallel 8 --release` — 167 passed, 0 failed
- [x] Spot-check fixed tests: `expressions/and_op` ✓, `expressions/or_op` ✓
- [ ] Reviewer: confirm the cosy-relocation hasn't broken any local-dev workflow that hardcoded `./cosy`