### PR TITLE
release: v1.0.0 — drop alpha tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.0.0-alpha.0"
+version = "1.0.0"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
Bumps rosy from 1.0.0-alpha.0 to 1.0.0 stable.

Note: existing packages pinned to ^0.42 (e.g. libcosy v1.0.0) will still fail the rosy_version compatibility check. Those manifests need a follow-up to broaden their requirement (e.g. ">=0.42, <2.0").