### PR TITLE
chore: update libcosy MODULE refs to v1.0.1

### DIFF
--- a/examples/libcosy_basic.rosy
+++ b/examples/libcosy_basic.rosy
@@ -11,7 +11,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (DA 8) M;
 

--- a/examples/ring_analysis.rosy
+++ b/examples/ring_analysis.rosy
@@ -43,7 +43,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (RE) RESULT;
 VARIABLE (DA 8) M_TURN;

--- a/examples/tests/test_libcosy_cocr.rosy
+++ b/examples/tests/test_libcosy_cocr.rosy
@@ -10,7 +10,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (CD 8) IAP;
 VARIABLE (CD 8) MID;

--- a/examples/tests/test_libcosy_helpers.rosy
+++ b/examples/tests/test_libcosy_helpers.rosy
@@ -10,7 +10,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (ST) LIN;
 VARIABLE (VE 64) WORD;

--- a/examples/tests/test_libcosy_rays.rosy
+++ b/examples/tests/test_libcosy_rays.rosy
@@ -8,7 +8,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (DA 8) MSC_COPY;
 VARIABLE (RE) I;

--- a/examples/tests/test_libcosy_smoke.rosy
+++ b/examples/tests/test_libcosy_smoke.rosy
@@ -2,7 +2,7 @@
   test_libcosy_smoke.rosy -- Smoke test for libcosy
 
   Confirms that:
-   * `MODULE GITHUB "rosy-team/libcosy" "v1.0.0";` fetches the tagged source
+   * `MODULE GITHUB "rosy-team/libcosy" "v1.0.1";` fetches the tagged source
      tarball, validates the Rosy.toml manifest, and splices libcosy/mod.rosy.
    * libcosy/globals.rosy parses and its declarations (PI, NRAY, ...) are
      visible at the top level after splicing.
@@ -17,7 +17,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (RE) RESULT;
 

--- a/examples/tests/test_libcosy_spin_e2e.rosy
+++ b/examples/tests/test_libcosy_spin_e2e.rosy
@@ -11,7 +11,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (RE) I;
 VARIABLE (RE) J;

--- a/examples/tests/test_libcosy_spos.rosy
+++ b/examples/tests/test_libcosy_spos.rosy
@@ -8,7 +8,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 OV 2 2 0;
 RP 1 1 1;

--- a/examples/tests/test_libcosy_twiss.rosy
+++ b/examples/tests/test_libcosy_twiss.rosy
@@ -10,7 +10,7 @@
 
 BEGIN;
 
-MODULE GITHUB "rosy-team/libcosy" "v1.0.0";
+MODULE GITHUB "rosy-team/libcosy" "v1.0.1";
 
 VARIABLE (DA 8) F_GT;
 VARIABLE (DA 4) MU_GT;


### PR DESCRIPTION
Bumps all `MODULE GITHUB "rosy-team/libcosy" "v1.0.0"` references in examples and integration tests to v1.0.1, picking up the broadened `rosy_version` requirement (>=0.42.0, <2.0.0) so the examples load against rosy 1.0.0 stable.

Note: this commit is intentionally scoped to refs only — the rosy version bump itself lives on `release/v1.0.0`. Sequence the merges so that branch lands first (or alongside this one).