### PR TITLE
fix: PLOOP works inside nested procedures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 
 [lib]

--- a/rosy/assets/output_template/main.rs
+++ b/rosy/assets/output_template/main.rs
@@ -13,8 +13,9 @@ use num_complex::Complex64;
 fn main_wrapper() -> Result<()> {
 	let start = std::time::Instant::now();
 	// <MPI_START>
-	let rosy_mpi_context = RosyMPIContext::new()
+	let mut rosy_mpi_context_inner = RosyMPIContext::new()
 		.context("Failed to initialize Rosy MPI context")?;
+	let rosy_mpi_context: &mut RosyMPIContext = &mut rosy_mpi_context_inner;
 	let group_num = rosy_mpi_context.get_group_num(&mut  &mut 1.0f64)
 		.context("Failed to get group number")? + 1.0f64;
 	// <MPI_END>

--- a/rosy/src/program/statements/core/procedure/mod.rs
+++ b/rosy/src/program/statements/core/procedure/mod.rs
@@ -339,6 +339,16 @@ impl Transpile for ProcedureStatement {
         let serialized_args: Vec<String> = {
             let mut serialized_args = Vec::new();
             for var_name in requested_variables.iter() {
+                // rosy_mpi_context is a transpiler-injected runtime singleton
+                // (used by PLOOP, see ploop/mod.rs). It threads through the
+                // procedure call chain as a typed reference so PLOOP works
+                // inside nested procedures, not just at top-level.
+                if var_name == "rosy_mpi_context" {
+                    serialized_args
+                        .push("rosy_mpi_context: &mut RosyMPIContext".to_string());
+                    continue;
+                }
+
                 let Some(var_data) = inner_context.variables.get(var_name) else {
                     errors.push(
                         anyhow!(

--- a/rosy/src/program/statements/core/procedure_call/mod.rs
+++ b/rosy/src/program/statements/core/procedure_call/mod.rs
@@ -137,6 +137,16 @@ impl Transpile for ProcedureCallStatement {
         let mut serialized_args = Vec::new();
         // Serialize the requested variables from the procedure context
         for var in &proc_context.requested_variables {
+            // rosy_mpi_context is the same `&mut RosyMPIContext` shape at
+            // top-level (via the template's indirection) and inside procedure
+            // bodies (as a parameter). Pass the binding bare and let Rust
+            // auto-reborrow; the surrounding scope's request propagation
+            // happens via line 281's `requested_variables.extend(...)`.
+            if var == "rosy_mpi_context" {
+                serialized_args.push("rosy_mpi_context".to_string());
+                continue;
+            }
+
             let var_data = context.variables.get(var).ok_or(vec![anyhow!(
                 "Could not find variable '{}' requested by procedure '{}'",
                 var,


### PR DESCRIPTION
PLOOP emits code that references rosy_mpi_context, a runtime singleton declared in main_wrapper(). At top-level this works because the binding is in scope. Inside procedures (which transpile to free fns), the binding isn't visible — and the existing "requested variable" mechanism that threads outer vars through procedure parameters tried to look rosy_mpi_context up in the variables map, where it doesn't exist (it's not a Rosy-level variable). Both the procedure-side parameter serialization and the call-site arg serialization failed with "Variable 'rosy_mpi_context' was requested but not found in context!".

Three coordinated changes:

1. assets/output_template/main.rs — top-level rosy_mpi_context now has the same `&mut RosyMPIContext` shape it has as a procedure parameter (via an indirection through an owned `_inner` local). Uniform shape means call sites can pass `rosy_mpi_context` bare and Rust auto-reborrows in both contexts, no scope tracking needed.

2. procedure/mod.rs — special-case rosy_mpi_context in the parameter list, emitting `rosy_mpi_context: &mut RosyMPIContext` directly without a variables-map lookup.

3. procedure_call/mod.rs — special-case rosy_mpi_context at the call site, emitting it bare. The existing `requested_variables.extend(...)` propagation handles plumbing the request up the procedure chain, so PLOOP nested arbitrarily deep just works.

Bumps rosy to 1.0.1 (patch — bug fix).