### PR TITLE
feat: COSY-compat multi-dim indexing & PLOOP last-dim partition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/examples/indexing_syntax.rosy
+++ b/examples/indexing_syntax.rosy
@@ -1,0 +1,31 @@
+BEGIN;
+    {Demonstrates the three equivalent indexing notations for arrays:
+        - bracket form:   X[I, J, K]
+        - chained parens: X(I)(J)(K)
+        - COSY parens:    X(I, J, K)   <- COSY INFINITY native form
+     Also exercises partial indexing (fewer indices than dimensions)
+     to slice down to a lower-dimensional view.}
+    PROCEDURE RUN;
+        VARIABLE (RE 2 3 4) X;
+        VARIABLE (RE) V;
+
+        LOOP I 1 2;
+            LOOP J 1 3;
+                LOOP K 1 4;
+                    X(I, J, K) := 100*I + 10*J + K;
+                ENDLOOP;
+            ENDLOOP;
+        ENDLOOP;
+
+        {All three should print 234}
+        WRITE 6 "Bracket form:   " X[2, 3, 4];
+        WRITE 6 "Chained parens: " X(2)(3)(4);
+        WRITE 6 "COSY parens:    " X(2, 3, 4);
+
+        {Partial index: X(1, 2) leaves the last dimension free}
+        V := X(1, 2)(3);
+        WRITE 6 "Partial index:  " V;
+    ENDPROCEDURE;
+
+    RUN;
+END;

--- a/examples/ploop_2d.rosy
+++ b/examples/ploop_2d.rosy
@@ -1,0 +1,20 @@
+BEGIN;
+    {COSY-style 2D PLOOP: parallel iterator is the LAST index.
+     X has shape (4 rows × NP cols); each rank fills its own column.}
+    VARIABLE (RE) NP;
+    NP := 3;
+    VARIABLE (RE 4 NP) X;
+
+    PLOOP P 1 NP;
+        LOOP J 1 4;
+            X(J, P) := 100*P + J;
+        ENDLOOP;
+    ENDPLOOP X;
+
+    WRITE 6 "X laid out as 4 rows × NP cols:";
+    LOOP J 1 4;
+        LOOP P 1 NP;
+            WRITE 6 "  X(" ST(J) "," ST(P) ") = " ST(X(J, P));
+        ENDLOOP;
+    ENDLOOP;
+END;

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2024"
 
 [lib]

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 
 [lib]

--- a/rosy/src/program/expressions/core/var_expr/mod.rs
+++ b/rosy/src/program/expressions/core/var_expr/mod.rs
@@ -11,7 +11,7 @@
 //! | Paren Groups | Args per Group | Bracket Indices | Result |
 //! |-------------|----------------|-----------------|--------|
 //! | 0 | — | any | Variable |
-//! | 1 | multiple | — | Function call |
+//! | 1 | multiple | — | Context-dependent: function call vs COSY-style multi-dim index |
 //! | 1 | 1 | — | Context-dependent (see below) |
 //! | ≥2 | 1 each | — | Multi-dim index (Variable) |
 //!
@@ -106,15 +106,39 @@ impl VarExpr {
             1 => {
                 let num_args = ident.paren_groups[0].len();
                 if num_args > 1 {
-                    // Multiple args in one paren group → function call
-                    // But must not also have bracket indices
-                    if has_brackets {
-                        return Err(vec![anyhow::anyhow!(
-                            "'{}': function call with bracket indexing is not valid",
-                            ident.name
-                        )]);
+                    // Multiple args in one paren group — could be either a
+                    // function call `FUNC(a, b)` or COSY-style multi-dim
+                    // indexing `X(I, J)`. Disambiguate via the symbol table.
+                    let is_var = context.variables.contains_key(&ident.name);
+                    let is_func = context.functions.contains_key(&ident.name);
+
+                    let func_accepts = is_func
+                        && context.functions.get(&ident.name).unwrap().args.len() == num_args;
+                    let var_accepts = is_var && {
+                        let v = context.variables.get(&ident.name).unwrap();
+                        // VE only accepts a single index, so it can never satisfy
+                        // a multi-arg group; fall through to function-call routing.
+                        v.data.r#type.base_type != crate::rosy_lib::RosyBaseType::VE
+                            && num_args <= v.data.r#type.dimensions
+                    };
+
+                    let route_as_call = match (func_accepts, var_accepts) {
+                        (true, _) => true,           // function arity matches — prefer call
+                        (false, true) => false,      // only variable fits — multi-dim index
+                        (false, false) => is_func || !is_var, // surface the more informative error downstream
+                    };
+
+                    if route_as_call {
+                        if has_brackets {
+                            return Err(vec![anyhow::anyhow!(
+                                "'{}': function call with bracket indexing is not valid",
+                                ident.name
+                            )]);
+                        }
+                        Ok(VarExprKind::FunctionCall)
+                    } else {
+                        Ok(VarExprKind::Variable)
                     }
-                    Ok(VarExprKind::FunctionCall)
                 } else {
                     // Single paren group, single arg → check context
                     let is_var = context.variables.contains_key(&ident.name);
@@ -159,18 +183,10 @@ impl VarExpr {
                 }
             }
             _ => {
-                // Multiple paren groups → multi-dimensional indexing
-                // Validate: each group must have exactly one arg
-                for (i, group) in ident.paren_groups.iter().enumerate() {
-                    if group.len() != 1 {
-                        return Err(vec![anyhow::anyhow!(
-                            "'{}': paren group {} has {} args — multi-dimensional indexing requires exactly 1 arg per group",
-                            ident.name,
-                            i + 1,
-                            group.len()
-                        )]);
-                    }
-                }
+                // Multiple paren groups → multi-dimensional indexing.
+                // Any mix of group sizes is allowed (e.g. `X(1, 2)(3)` is the
+                // same as `X(1)(2)(3)`); total index count is validated against
+                // the variable's dimensions during type_of().
                 Ok(VarExprKind::Variable)
             }
         }
@@ -228,7 +244,20 @@ impl TranspileableExpr for VarExpr {
             1 => {
                 let num_args = ident.paren_groups[0].len();
                 if num_args > 1 {
-                    true
+                    // Mirror classify(): prefer function only when its arity
+                    // matches; otherwise treat as multi-dim variable indexing
+                    // when the variable can absorb that many indices.
+                    let func_accepts = is_func
+                        && ctx.functions.get(&ident.name)
+                            .map(|(_, args)| args.len() == num_args)
+                            .unwrap_or(false);
+                    if func_accepts {
+                        true
+                    } else if is_var {
+                        false
+                    } else {
+                        is_func
+                    }
                 } else {
                     !is_var && is_func
                 }

--- a/rosy/src/program/expressions/core/variable_identifier/mod.rs
+++ b/rosy/src/program/expressions/core/variable_identifier/mod.rs
@@ -72,8 +72,12 @@ impl VariableIdentifier {
     }
 
     /// Total number of indexing dimensions (only valid for variable indexing, not function calls).
+    ///
+    /// Counts every expression across all paren groups plus every bracket index.
+    /// Supports both chained `X(I)(J)` (groups of one) and COSY-style `X(I, J)`
+    /// (a single group of many).
     pub fn num_index_dimensions(&self) -> usize {
-        self.paren_groups.len() + self.bracket_indices.len()
+        self.paren_groups.iter().map(|g| g.len()).sum::<usize>() + self.bracket_indices.len()
     }
 }
 

--- a/rosy/src/program/statements/core/ploop/mod.rs
+++ b/rosy/src/program/statements/core/ploop/mod.rs
@@ -11,13 +11,32 @@
 //! ENDPLOOP output;
 //! ```
 //!
-//! ## Example
+//! ## Partitioning convention (COSY INFINITY compatible)
+//!
+//! The PLOOP iterator partitions the **last (innermost)** dimension of the
+//! output array. Each rank `g` writes into `output[...][g]` and the gather
+//! broadcasts each inner Vec independently. For 1D outputs (or `VE`) this is
+//! a no-op wrapper — `coordinate()` runs directly on the value.
+//!
+//! ## Example (1D — most common)
 //!
 //! ```text
 //! VARIABLE (VE) results;
 //! PLOOP I 1 100;
 //!     results := results & (I * 2);
 //! ENDPLOOP results;
+//! ```
+//!
+//! ## Example (2D — per-rank column)
+//!
+//! ```text
+//! { Each rank fills its column of a 4-row × NP-col matrix. }
+//! VARIABLE (RE 4 NP) X;
+//! PLOOP P 1 NP;
+//!     LOOP J 1 4;
+//!         X(J, P) := 100*P + J;
+//!     ENDLOOP;
+//! ENDPLOOP X;
 //! ```
 
 use anyhow::{Context, Error, Result, anyhow, bail, ensure};
@@ -305,11 +324,43 @@ impl Transpile for PLoopStatement {
                 self.iterator,
             )
         };
-        let coordination_serialization = format!(
-            "rosy_mpi_context.coordinate(&mut {}, {}u8, &mut __ploop_end)?;",
-            output_serialization,
-            self.commutivityfrom_rule.unwrap_or(1),
-        );
+        // Partition the OUTPUT array's last (innermost) dimension across MPI
+        // ranks, matching COSY INFINITY's convention. For a 2D output declared
+        // `(RE D1 NP) X`, each rank g writes into `X[i][g]` for every `i`, and
+        // the gather broadcasts every inner Vec independently.
+        //
+        // For 1D arrays / VE, no outer loops are emitted — `coordinate()` runs
+        // directly on the value, identical to the pre-1.2 behavior.
+        let coordination_serialization = {
+            let rank = if output_type == RosyType::VE() {
+                1
+            } else {
+                output_type.dimensions
+            };
+            let outer_loop_count = rank.saturating_sub(1);
+            let commut = self.commutivityfrom_rule.unwrap_or(1);
+
+            let mut accessor = output_serialization.clone();
+            let mut opens = String::new();
+            for i in 0..outer_loop_count {
+                let idx = format!("__ploop_dim_{}", i);
+                opens.push_str(&format!(
+                    "for {} in 0..{}.len() {{\n\t",
+                    idx, accessor
+                ));
+                accessor = format!("{}[{}]", accessor, idx);
+            }
+            let inner_call = format!(
+                "rosy_mpi_context.coordinate(&mut {}, {}u8, &mut __ploop_end)?;",
+                accessor, commut,
+            );
+            let closes = "}".repeat(outer_loop_count);
+            if outer_loop_count == 0 {
+                inner_call
+            } else {
+                format!("{}{}\n\t{}", opens, inner_call, closes)
+            }
+        };
         let serialization = format!(
             "{{\n\t{}\n\n{}\n\n\t{}\n}}",
             iterator_declaration_serialization,


### PR DESCRIPTION
## Summary

Two changes addressing a coworker's email about COSY → Rosy parity gaps:

- **`X(I, J, K)` multi-dim indexing** — COSY users' native notation now works alongside Rosy's existing chained `X(I)(J)(K)` and bracket `X[I, J, K]` forms. Classifier disambiguates against the symbol table on the >1-arg branch; strictly additive (no input that previously succeeded takes a different path).
- **PLOOP last-dim partition (BREAKING)** — Flipped to match COSY convention: PLOOP iterator partitions the *last* (innermost) dim of the output array. Transpiler wraps `coordinate()` in N-1 outer loops over leading dims. For 1D/VE outputs, codegen is byte-identical to pre-1.2.

The third email item (COSY-style `VARIABLE X 1 NP;` syntax) was deliberately not addressed — the `--cosy-syntax` hook in `rosy.pest:132-134` already exists for if/when it's needed, and the coworker's email only notes the difference rather than requesting it.

## Migration

Every PLOOP output in the repository is 1D — zero in-repo migration. External users with multi-dim PLOOP outputs:

- Swap dim order: `(RE NP 4) X` → `(RE 4 NP) X`
- Move PLOOP iterator from first to last in indexing: `X(P, J)` → `X(J, P)`

## Test plan

- [x] `cargo test --release` — 20 passing, 0 failing
- [x] Top-level `examples/*.rosy` regression — same 3 baseline failures as master (`briefdemo_nondyn`, `mpi_info`, `ploop` — all NixOS env / pre-existing, not introduced)
- [x] New `examples/indexing_syntax.rosy` exercises all three notations + partial indexing
- [x] New `examples/ploop_2d.rosy` exercises COSY-style 4×NP layout
- [x] Inspected emitted Rust for 1D and 2D PLOOP — wrapper applied only when rank > 1
- [x] Side-by-side comparison against `./assets/cosy` confirmed the layout mismatch (`X(J, P)` in COSY = `X(P, J)` in old Rosy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)