### PR TITLE
feat: DA^RE power, VE indexed-assign fix, LOOP while-loop rewrite (v1.3.0)

### DIFF
--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2024"
 
 [lib]

--- a/rosy/src/embedded.rs
+++ b/rosy/src/embedded.rs
@@ -99,7 +99,7 @@ fn generate_cargo_toml(uses_mpi: bool, optimized: bool) -> String {
     };
 
     format!(
-        "[package]\nname = \"rosy_output\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\nanyhow = \"1.0\"\n{mpi_dep}\nnum-complex = \"0.4\"\n{profile_section}"
+        "[workspace]\n\n[package]\nname = \"rosy_output\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\nanyhow = \"1.0\"\n{mpi_dep}\nnum-complex = \"0.4\"\n{profile_section}"
     )
 }
 

--- a/rosy/src/program/statements/core/assign/mod.rs
+++ b/rosy/src/program/statements/core/assign/mod.rs
@@ -141,7 +141,11 @@ impl TranspileableStatement for AssignStatement {
                 // the declared dimensions by the number of indices.
                 let mut explicit_type = node.resolved.as_ref().unwrap().clone();
                 let num_indices = self.identifier.num_index_dimensions();
-                explicit_type.dimensions = explicit_type.dimensions.saturating_sub(num_indices);
+                if num_indices > 0 && explicit_type.base_type == RosyBaseType::VE && explicit_type.dimensions == 0 {
+                    explicit_type = RosyType::RE();
+                } else {
+                    explicit_type.dimensions = explicit_type.dimensions.saturating_sub(num_indices);
+                }
                 if let Ok(new_type) = resolver.evaluate_recipe(&recipe) {
                     if new_type != explicit_type {
                         let scope_str = if ctx.scope_path.is_empty() {

--- a/rosy/src/program/statements/core/loop/mod.rs
+++ b/rosy/src/program/statements/core/loop/mod.rs
@@ -268,11 +268,11 @@ impl Transpile for LoopStatement {
             }
         };
         requested_variables.extend(end_output.requested_variables.iter().cloned());
-        let step_serialization = if let Some(step_expr) = &self.step {
+        let step_value: Option<String> = if let Some(step_expr) = &self.step {
             match step_expr.transpile(context) {
                 Ok(output) => {
                     requested_variables.extend(output.requested_variables.iter().cloned());
-                    format!(".step_by({} as usize)", output.as_value())
+                    Some(output.as_value().to_string())
                 }
                 Err(vec_err) => {
                     for e in vec_err {
@@ -285,19 +285,33 @@ impl Transpile for LoopStatement {
                 }
             }
         } else {
-            String::from("")
+            None
         };
 
-        let serialization = format!(
-            "for {} in (({} as usize)..=({} as usize)){} {{\n\tlet mut {} = {} as RE;\n{}\n}}",
-            self.iterator,
-            start_output.as_value(),
-            end_output.as_value(),
-            step_serialization,
-            self.iterator,
-            self.iterator,
-            indent(serialized_statements.join("\n"))
-        );
+        let iter = &self.iterator;
+        let start = start_output.as_value();
+        let end = end_output.as_value();
+        let body = indent(serialized_statements.join("\n"));
+        let serialization = if let Some(step) = &step_value {
+            format!(
+                "let mut {iter}: RE = ({start}) as RE;\n\
+                 let __{iter}_end: RE = ({end}) as RE;\n\
+                 let __{iter}_step: RE = ({step}) as RE;\n\
+                 while (__{iter}_step > 0.0_f64 && {iter} <= __{iter}_end) || (__{iter}_step <= 0.0_f64 && {iter} >= __{iter}_end) {{\n\
+                 {body}\n\
+                 \t{iter} += __{iter}_step;\n\
+                 }}"
+            )
+        } else {
+            format!(
+                "let mut {iter}: RE = ({start}) as RE;\n\
+                 let __{iter}_end: RE = ({end}) as RE;\n\
+                 while {iter} <= __{iter}_end {{\n\
+                 {body}\n\
+                 \t{iter} += 1.0_f64;\n\
+                 }}"
+            )
+        };
         if errors.is_empty() {
             Ok(TranspilationOutput {
                 serialization,

--- a/rosy/src/rosy_lib/core/polval.rs
+++ b/rosy/src/rosy_lib/core/polval.rs
@@ -406,7 +406,7 @@ fn evaluate_cd_at_cd(poly: &CD, args: &[CD], na: usize) -> Result<CD> {
 
 /// CD-typed exponentiation by repeated squaring. Mirrors `da_powi`.
 #[inline]
-fn cd_powi(base: &CD, exp: u8) -> Result<CD> {
+pub fn cd_powi(base: &CD, exp: u8) -> Result<CD> {
     Ok(match exp {
         0 => CD::from_coeff(num_complex::Complex64::new(1.0, 0.0)),
         1 => base.clone(),
@@ -447,7 +447,7 @@ fn cd_powi(base: &CD, exp: u8) -> Result<CD> {
 
 /// Compute base^exp for small u8 exponents using exponentiation-by-squaring.
 #[inline]
-fn da_powi(base: &DA, exp: u8) -> Result<DA> {
+pub fn da_powi(base: &DA, exp: u8) -> Result<DA> {
     Ok(match exp {
         0 => DA::from_coeff(1.0),
         1 => base.clone(),

--- a/rosy/src/rosy_lib/operators/pow.rs
+++ b/rosy/src/rosy_lib/operators/pow.rs
@@ -12,15 +12,18 @@
 
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
-use crate::rosy_lib::{RE, VE};
+use crate::rosy_lib::{RE, VE, DA, CD};
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
+use crate::rosy_lib::core::polval::{da_powi, cd_powi};
 
 /// Type compatibility registry for power/exponentiation operator.
-/// 
+///
 /// This is the single source of truth for what type combinations are allowed.
 pub const POW_REGISTRY: &[TypeRule] = &[
     TypeRule::new("RE", "RE", "RE", "2", "3"),
     TypeRule::with_comment("VE", "RE", "VE", "1&2&3", "2", "Raise to Real power componentwise"),
+    TypeRule::new("DA", "RE", "DA", "DA(1)", "2"),
+    TypeRule::new("CD", "RE", "CD", "CD(1)", "2"),
 ];
 
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
@@ -46,6 +49,22 @@ impl RosyPow<&RE> for &VE {
     type Output = VE;
     fn rosy_pow(self, rhs: &RE) -> Result<Self::Output> {
         Ok(self.iter().map(|x| x.powf(*rhs)).collect())
+    }
+}
+
+// DA ^ RE (repeated squaring via da_powi; truncates exponent to u8)
+impl RosyPow<&RE> for &DA {
+    type Output = DA;
+    fn rosy_pow(self, rhs: &RE) -> Result<Self::Output> {
+        da_powi(self, *rhs as u8)
+    }
+}
+
+// CD ^ RE (repeated squaring via cd_powi; truncates exponent to u8)
+impl RosyPow<&RE> for &CD {
+    type Output = CD;
+    fn rosy_pow(self, rhs: &RE) -> Result<Self::Output> {
+        cd_powi(self, *rhs as u8)
     }
 }
 


### PR DESCRIPTION
## Summary

- **DA/CD ^ RE operator**: `da_powi`/`cd_powi` in `polval.rs` made `pub`; new `TypeRule` entries and `RosyPow<&RE>` impls added for both `DA` and `CD` in `pow.rs`
- **VE indexed assignment type fix**: `wire_inference_edges` in `assign/mod.rs` now correctly resolves `V(i) := expr` as assigning to `RE` when `V` is a plain `VE` (previously stayed `VE`, causing false type errors)
- **LOOP while-loop rewrite**: `loop/mod.rs` now generates a `while`-loop instead of `for I in (start..=end).step_by(...)` — fixes float step support and allows iterator variable mutation inside the body
- **embedded.rs**: add `[workspace]` section to generated `Cargo.toml` so the `rosy_output` crate doesn't accidentally join the parent workspace

## Test plan
- [x] `DA ^ RE` integration test: `X := DA(1); R := X ^ 3;` produces x₁³ term correctly
- [x] `V(2) := 20.0; E := V(2)` round-trips without type error
- [x] `LOOP I 1 5` sums to 15; `LOOP I 0 2 1` sums to 3
- [x] `cargo test` — 21/21 pass