### PR TITLE
fix: operator correctness, VE safety, perf, dep cleanup (v1.3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,13 +1056,12 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "1.2.2"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "clap",
  "flate2",
  "impls",
- "lazy_static",
  "libm",
  "memory-stats",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ exclude = [ ".rosy_output", ".rosy_test_cache" ]
 anyhow = "1.0"
 pest = "2.7"
 pest_derive = "2.7"
-lazy_static = "1.4"
 impls = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2024"
 
 [lib]
@@ -18,7 +18,6 @@ nightly-simd = []
 anyhow.workspace = true
 pest.workspace = true
 pest_derive.workspace = true
-lazy_static.workspace = true
 impls.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/rosy/src/ast.rs
+++ b/rosy/src/ast.rs
@@ -41,36 +41,34 @@ use pest_derive::Parser;
 pub struct CosyParser;
 
 // Create a static PrattParser for expressions
-lazy_static::lazy_static! {
-    pub static ref PRATT_PARSER: PrattParser<Rule> = {
-        use pest::pratt_parser::{Assoc::*, Op};
-        use Rule::*;
+pub static PRATT_PARSER: std::sync::LazyLock<PrattParser<Rule>> = std::sync::LazyLock::new(|| {
+    use pest::pratt_parser::{Assoc::*, Op};
+    use Rule::*;
 
-        // Precedence is defined from lowest to highest priority
-        // Following COSY INFINITY priorities:
-        // - Priority 2: Concatenation (&), Equality (=), Not-Equals (#), Less/Greater, comparison
-        // - Priority 3: Addition (+), Subtraction (-)
-        // - Priority 4: Multiplication (*), Division (/)
-        // - Priority 5: Exponentiation (^) - right-associative
-        // - Priority 6: Extraction (|), Derivation (%)
-        PrattParser::new()
-            // Lowest precedence (Priority 0): logical OR
-            .op(Op::infix(or_op, Left))
-            // Priority 1: logical AND (binds tighter than OR)
-            .op(Op::infix(and_op, Left))
-            // Priority 2: concatenation, equality, not-equals, comparisons
-            .op(Op::infix(concat, Left) | Op::infix(eq, Left) | Op::infix(neq, Left)
-                | Op::infix(lt, Left) | Op::infix(gt, Left) | Op::infix(lte, Left) | Op::infix(gte, Left))
-            // Priority 3: Addition and Subtraction
-            .op(Op::infix(add, Left) | Op::infix(sub, Left))
-            // Priority 4: Multiplication and Division
-            .op(Op::infix(mult, Left) | Op::infix(div, Left))
-            // Priority 5: Exponentiation (right-associative, like math convention)
-            .op(Op::infix(pow, Right))
-            // Priority 6: Extraction (|) and Derivation (%)
-            .op(Op::infix(extract, Left) | Op::infix(derive, Left))
-    };
-}
+    // Precedence is defined from lowest to highest priority
+    // Following COSY INFINITY priorities:
+    // - Priority 2: Concatenation (&), Equality (=), Not-Equals (#), Less/Greater, comparison
+    // - Priority 3: Addition (+), Subtraction (-)
+    // - Priority 4: Multiplication (*), Division (/)
+    // - Priority 5: Exponentiation (^) - right-associative
+    // - Priority 6: Extraction (|), Derivation (%)
+    PrattParser::new()
+        // Lowest precedence (Priority 0): logical OR
+        .op(Op::infix(or_op, Left))
+        // Priority 1: logical AND (binds tighter than OR)
+        .op(Op::infix(and_op, Left))
+        // Priority 2: concatenation, equality, not-equals, comparisons
+        .op(Op::infix(concat, Left) | Op::infix(eq, Left) | Op::infix(neq, Left)
+            | Op::infix(lt, Left) | Op::infix(gt, Left) | Op::infix(lte, Left) | Op::infix(gte, Left))
+        // Priority 3: Addition and Subtraction
+        .op(Op::infix(add, Left) | Op::infix(sub, Left))
+        // Priority 4: Multiplication and Division
+        .op(Op::infix(mult, Left) | Op::infix(div, Left))
+        // Priority 5: Exponentiation (right-associative, like math convention)
+        .op(Op::infix(pow, Right))
+        // Priority 6: Extraction (|) and Derivation (%)
+        .op(Op::infix(extract, Left) | Op::infix(derive, Left))
+});
 
 pub trait FromRule: Sized {
     fn from_rule(pair: pest::iterators::Pair<Rule>) -> Result<Option<Self>>;

--- a/rosy/src/program/expressions/operators/arithmetic/add/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/add/mod.rs
@@ -78,15 +78,13 @@ impl FromRule for AddExpr {
 }
 impl TranspileableExpr for AddExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::add::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot add types '{}' and '{}' together!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::add::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot add types '{}' and '{}' together!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/arithmetic/div/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/div/mod.rs
@@ -73,15 +73,13 @@ impl FromRule for DivExpr {
 }
 impl TranspileableExpr for DivExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::div::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot divide types '{}' and '{}' together!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::div::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot divide types '{}' and '{}' together!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/arithmetic/mult/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/mult/mod.rs
@@ -75,15 +75,13 @@ impl FromRule for MultExpr {
 }
 impl TranspileableExpr for MultExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::mult::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot multiply types '{}' and '{}' together!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::mult::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot multiply types '{}' and '{}' together!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,
@@ -122,7 +120,7 @@ impl Transpile for MultExpr {
         let right_type = self.right.type_of(context).map_err(|e| vec![e])?;
         if crate::rosy_lib::operators::mult::get_return_type(&left_type, &right_type).is_none() {
             return Err(vec![anyhow!(
-                "Cannot add types '{}' and '{}' together!",
+                "Cannot multiply types '{}' and '{}' together!",
                 left_type,
                 right_type
             )]);

--- a/rosy/src/program/expressions/operators/arithmetic/sub/mod.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/sub/mod.rs
@@ -73,15 +73,13 @@ impl FromRule for SubExpr {
 }
 impl TranspileableExpr for SubExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::sub::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot subtract types '{}' and '{}' together!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::sub::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot subtract types '{}' and '{}' together!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/collection/concat/mod.rs
+++ b/rosy/src/program/expressions/operators/collection/concat/mod.rs
@@ -71,7 +71,7 @@ impl TranspileableExpr for ConcatExpr {
             .context("...while determining type of right side of concatenation")?;
 
         crate::rosy_lib::operators::concat::get_return_type(&left_type, &right_type)
-            .ok_or(anyhow::anyhow!(
+            .ok_or_else(|| anyhow::anyhow!(
                 "Cannot concatenate types '{}' and '{}' together!",
                 left_type,
                 right_type

--- a/rosy/src/program/expressions/operators/collection/extract/mod.rs
+++ b/rosy/src/program/expressions/operators/collection/extract/mod.rs
@@ -73,13 +73,12 @@ impl TranspileableExpr for ExtractExpr {
         })?;
 
         let result_type =
-            crate::rosy_lib::operators::extract::get_return_type(&object_type, &index_type).ok_or(
-                anyhow::anyhow!(
-                    "Cannot extract from type '{}' using index of type '{}'!",
-                    object_type,
-                    index_type
-                ),
-            )?;
+            crate::rosy_lib::operators::extract::get_return_type(&object_type, &index_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot extract from type '{}' using index of type '{}'!",
+                object_type,
+                index_type
+            ))?;
 
         Ok(result_type)
     }

--- a/rosy/src/program/expressions/operators/comparison/eq/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/eq/mod.rs
@@ -59,15 +59,13 @@ impl FromRule for EqExpr {
 }
 impl TranspileableExpr for EqExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::eq::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot compare types '{}' and '{}' for equality!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::eq::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot compare types '{}' and '{}' for equality!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/gt/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/gt/mod.rs
@@ -57,15 +57,13 @@ impl FromRule for GtExpr {
 }
 impl TranspileableExpr for GtExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::gt::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot compare types '{}' and '{}' with greater-than!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::gt::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot compare types '{}' and '{}' with greater-than!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/gte/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/gte/mod.rs
@@ -50,15 +50,13 @@ impl FromRule for GteExpr {
 }
 impl TranspileableExpr for GteExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::gte::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot compare types '{}' and '{}' with greater-than-or-equal!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::gte::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot compare types '{}' and '{}' with greater-than-or-equal!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/lt/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/lt/mod.rs
@@ -58,15 +58,13 @@ impl FromRule for LtExpr {
 }
 impl TranspileableExpr for LtExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::lt::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot compare types '{}' and '{}' with less-than!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::lt::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot compare types '{}' and '{}' with less-than!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/lte/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/lte/mod.rs
@@ -50,15 +50,13 @@ impl FromRule for LteExpr {
 }
 impl TranspileableExpr for LteExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::lte::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot compare types '{}' and '{}' with less-than-or-equal!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::lte::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot compare types '{}' and '{}' with less-than-or-equal!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/neq/mod.rs
+++ b/rosy/src/program/expressions/operators/comparison/neq/mod.rs
@@ -60,15 +60,13 @@ impl FromRule for NeqExpr {
 }
 impl TranspileableExpr for NeqExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::neq::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot compare types '{}' and '{}' for inequality!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::neq::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot compare types '{}' and '{}' for inequality!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/logical/and_op/mod.rs
+++ b/rosy/src/program/expressions/operators/logical/and_op/mod.rs
@@ -39,15 +39,13 @@ impl FromRule for AndExpr {
 }
 impl TranspileableExpr for AndExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::and::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot apply AND to types '{}' and '{}'!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::and::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot apply AND to types '{}' and '{}'!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/logical/and_op/test.fox
+++ b/rosy/src/program/expressions/operators/logical/and_op/test.fox
@@ -1,13 +1,13 @@
 BEGIN;
 PROCEDURE RUN;
     VARIABLE R 1;
-    R := LO(1) AND LO(1);
+    R := LO(1) * LO(1);
     WRITE 6 R;
-    R := LO(1) AND LO(0);
+    R := LO(1) * LO(0);
     WRITE 6 R;
-    R := LO(0) AND LO(1);
+    R := LO(0) * LO(1);
     WRITE 6 R;
-    R := LO(0) AND LO(0);
+    R := LO(0) * LO(0);
     WRITE 6 R;
 ENDPROCEDURE;
 RUN;

--- a/rosy/src/program/expressions/operators/logical/or_op/cosy_output.txt
+++ b/rosy/src/program/expressions/operators/logical/or_op/cosy_output.txt
@@ -1,0 +1,4 @@
+ TRUE
+ TRUE
+ TRUE
+ FALSE

--- a/rosy/src/program/expressions/operators/logical/or_op/mod.rs
+++ b/rosy/src/program/expressions/operators/logical/or_op/mod.rs
@@ -39,15 +39,13 @@ impl FromRule for OrExpr {
 }
 impl TranspileableExpr for OrExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::or::get_return_type(
-            &self.left.type_of(context)?,
-            &self.right.type_of(context)?,
-        )
-        .ok_or(anyhow::anyhow!(
-            "Cannot apply OR to types '{}' and '{}'!",
-            self.left.type_of(context)?,
-            self.right.type_of(context)?
-        ))
+        let left_type = self.left.type_of(context)?;
+        let right_type = self.right.type_of(context)?;
+        crate::rosy_lib::operators::or::get_return_type(&left_type, &right_type)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Cannot apply OR to types '{}' and '{}'!",
+                left_type, right_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/program/expressions/operators/logical/or_op/test.fox
+++ b/rosy/src/program/expressions/operators/logical/or_op/test.fox
@@ -1,13 +1,13 @@
 BEGIN;
 PROCEDURE RUN;
     VARIABLE R 1;
-    R := LO(1) OR LO(1);
+    R := LO(1) + LO(1);
     WRITE 6 R;
-    R := LO(1) OR LO(0);
+    R := LO(1) + LO(0);
     WRITE 6 R;
-    R := LO(0) OR LO(1);
+    R := LO(0) + LO(1);
     WRITE 6 R;
-    R := LO(0) OR LO(0);
+    R := LO(0) + LO(0);
     WRITE 6 R;
 ENDPROCEDURE;
 RUN;

--- a/rosy/src/program/expressions/operators/unary/not/mod.rs
+++ b/rosy/src/program/expressions/operators/unary/not/mod.rs
@@ -56,12 +56,12 @@ impl FromRule for NotExpr {
 }
 impl TranspileableExpr for NotExpr {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType> {
-        crate::rosy_lib::operators::not::get_return_type(&self.operand.type_of(context)?).ok_or(
-            anyhow::anyhow!(
+        let operand_type = self.operand.type_of(context)?;
+        crate::rosy_lib::operators::not::get_return_type(&operand_type)
+            .ok_or_else(|| anyhow::anyhow!(
                 "Cannot apply NOT to type '{}'!",
-                self.operand.type_of(context)?
-            ),
-        )
+                operand_type
+            ))
     }
     fn discover_expr_function_calls(
         &self,

--- a/rosy/src/rosy_lib/operators/add.rs
+++ b/rosy/src/rosy_lib/operators/add.rs
@@ -17,6 +17,8 @@ use anyhow::Result;
 use num_complex::Complex64;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, CM, VE, DA, CD, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for addition operator.
@@ -50,9 +52,12 @@ pub const ADD_REGISTRY: &[TypeRule] = &[
     TypeRule::new("CD", "CD", "CD", "DA(1)+CM(0&1)*DA(2)", "DA(3)+CM(4&5)*DA(6)"),
 ];
 
+static ADD_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(ADD_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    ADD_MAP.get_or_init(|| build_type_registry(ADD_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyAdd<Rhs = Self> {
@@ -115,6 +120,8 @@ impl RosyAdd<&RE> for &VE {
 impl RosyAdd<&VE> for &VE {
     type Output = VE;
     fn rosy_add(self, other: &VE) -> Result<Self::Output> {
+        anyhow::ensure!(self.len() == other.len(),
+            "Vector length mismatch in addition: {} vs {}", self.len(), other.len());
         Ok(self.iter()
             .zip(other.iter())
             .map(|(x, y)| x + y)

--- a/rosy/src/rosy_lib/operators/concat.rs
+++ b/rosy/src/rosy_lib/operators/concat.rs
@@ -16,6 +16,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, VE, DA, CD};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for concatenation operator.
@@ -49,9 +51,12 @@ pub const CONCAT_REGISTRY: &[TypeRule] = &[
     // GR & GR => GR is in COSY but GR type not implemented in Rosy yet
 ];
 
+static CONCAT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(CONCAT_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    CONCAT_MAP.get_or_init(|| build_type_registry(CONCAT_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyConcat<Rhs = Self> {

--- a/rosy/src/rosy_lib/operators/div.rs
+++ b/rosy/src/rosy_lib/operators/div.rs
@@ -16,6 +16,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, CM, VE, DA, CD};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for division operator.
@@ -48,9 +50,12 @@ pub const DIV_REGISTRY: &[TypeRule] = &[
     TypeRule::new("CD", "CD", "CD", "1+DA(1)+CM(2&3)*DA(2)", "2+DA(3)+CM(6&7)*DA(4)"),
 ];
 
+static DIV_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(DIV_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    DIV_MAP.get_or_init(|| build_type_registry(DIV_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyDiv<Rhs = Self> {
@@ -153,6 +158,8 @@ impl RosyDiv<&RE> for &VE {
 impl RosyDiv<&VE> for &VE {
     type Output = VE;
     fn rosy_div(self, other: &VE) -> Result<Self::Output> {
+        anyhow::ensure!(self.len() == other.len(),
+            "Vector length mismatch in division: {} vs {}", self.len(), other.len());
         Ok(self.iter()
             .zip(other.iter())
             .map(|(x, y)| x / y)

--- a/rosy/src/rosy_lib/operators/eq.rs
+++ b/rosy/src/rosy_lib/operators/eq.rs
@@ -16,6 +16,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for equality operator.
@@ -27,14 +29,17 @@ use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`eq.fox`)
 /// - Integration tests
 pub const EQ_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "3.14159", "3.14159", "Equality with epsilon tolerance"),
+    TypeRule::with_comment("RE", "RE", "LO", "3.14159", "3.14159", "Exact IEEE-754 equality (matches COSY behavior)"),
     TypeRule::with_comment("ST", "ST", "LO", "'hello'", "'hello'", "String equality"),
     TypeRule::with_comment("LO", "LO", "LO", "TRUE", "TRUE", "Logical equality"),
 ];
 
+static EQ_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(EQ_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    EQ_MAP.get_or_init(|| build_type_registry(EQ_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyEq<Rhs = Self> {
@@ -42,11 +47,11 @@ pub trait RosyEq<Rhs = Self> {
     fn rosy_eq(self, rhs: Rhs) -> Result<Self::Output>;
 }
 
-// RE = RE (with epsilon tolerance)
+// RE = RE (exact IEEE-754, matches COSY behavior)
 impl RosyEq<&RE> for &RE {
     type Output = LO;
     fn rosy_eq(self, rhs: &RE) -> Result<Self::Output> {
-        Ok((self - rhs).abs() < f64::EPSILON)
+        Ok(self == rhs)
     }
 }
 

--- a/rosy/src/rosy_lib/operators/extract.rs
+++ b/rosy/src/rosy_lib/operators/extract.rs
@@ -17,6 +17,8 @@ use anyhow::{Result, bail};
 
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, VE, CM, DA, CD};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 use crate::rosy_lib::taylor::monomial::Monomial;
 
@@ -43,9 +45,12 @@ pub const EXTRACT_REGISTRY: &[TypeRule] = &[
     TypeRule::with_comment("CD", "VE", "CM", "CD(1)", "0&1", "Extract CD coefficient by exponent vector"),
 ];
 
+static EXTRACT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(base: &RosyType, index: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(EXTRACT_REGISTRY);
-    registry.get(&(*base, *index)).copied()
+    EXTRACT_MAP.get_or_init(|| build_type_registry(EXTRACT_REGISTRY))
+        .get(&(*base, *index))
+        .copied()
 }
 
 /// Trait for extracting components from Rosy data types

--- a/rosy/src/rosy_lib/operators/gt.rs
+++ b/rosy/src/rosy_lib/operators/gt.rs
@@ -7,6 +7,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for greater-than operator.
@@ -15,9 +17,12 @@ pub const GT_REGISTRY: &[TypeRule] = &[
     TypeRule::with_comment("ST", "ST", "LO", "'banana'", "'apple'", "Lexicographic ordering"),
 ];
 
+static GT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(GT_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    GT_MAP.get_or_init(|| build_type_registry(GT_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyGt<Rhs = Self> {

--- a/rosy/src/rosy_lib/operators/gte.rs
+++ b/rosy/src/rosy_lib/operators/gte.rs
@@ -9,6 +9,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for greater-than-or-equal operator.
@@ -17,9 +19,12 @@ pub const GTE_REGISTRY: &[TypeRule] = &[
     TypeRule::with_comment("ST", "ST", "LO", "'banana'", "'banana'", "Lexicographic ordering"),
 ];
 
+static GTE_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(GTE_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    GTE_MAP.get_or_init(|| build_type_registry(GTE_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyGte<Rhs = Self> {

--- a/rosy/src/rosy_lib/operators/lt.rs
+++ b/rosy/src/rosy_lib/operators/lt.rs
@@ -7,6 +7,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for less-than operator.
@@ -15,9 +17,12 @@ pub const LT_REGISTRY: &[TypeRule] = &[
     TypeRule::with_comment("ST", "ST", "LO", "'apple'", "'banana'", "Lexicographic ordering"),
 ];
 
+static LT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(LT_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    LT_MAP.get_or_init(|| build_type_registry(LT_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyLt<Rhs = Self> {

--- a/rosy/src/rosy_lib/operators/lte.rs
+++ b/rosy/src/rosy_lib/operators/lte.rs
@@ -9,6 +9,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for less-than-or-equal operator.
@@ -17,9 +19,12 @@ pub const LTE_REGISTRY: &[TypeRule] = &[
     TypeRule::with_comment("ST", "ST", "LO", "'apple'", "'apple'", "Lexicographic ordering"),
 ];
 
+static LTE_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(LTE_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    LTE_MAP.get_or_init(|| build_type_registry(LTE_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyLte<Rhs = Self> {

--- a/rosy/src/rosy_lib/operators/mult.rs
+++ b/rosy/src/rosy_lib/operators/mult.rs
@@ -16,6 +16,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, CM, VE, DA, CD, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for multiplication operator.
@@ -49,9 +51,12 @@ pub const MULT_REGISTRY: &[TypeRule] = &[
     TypeRule::new("CD", "CD", "CD", "DA(1)+CM(0&1)*DA(2)", "DA(3)+CM(4&5)*DA(6)"),
 ];
 
+static MULT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(MULT_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    MULT_MAP.get_or_init(|| build_type_registry(MULT_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyMult<Rhs = Self> {
@@ -120,6 +125,8 @@ impl RosyMult<&RE> for &VE {
 impl RosyMult<&VE> for &VE {
     type Output = VE;
     fn rosy_mult(self, other: &VE) -> Result<Self::Output> {
+        anyhow::ensure!(self.len() == other.len(),
+            "Vector length mismatch in multiplication: {} vs {}", self.len(), other.len());
         Ok(self.iter()
             .zip(other.iter())
             .map(|(x, y)| x * y)

--- a/rosy/src/rosy_lib/operators/neq.rs
+++ b/rosy/src/rosy_lib/operators/neq.rs
@@ -16,6 +16,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, ST, LO};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for not-equals operator.
@@ -27,14 +29,17 @@ use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`neq.fox`)
 /// - Integration tests
 pub const NEQ_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "3.14159", "2.71828", "Not-equals with epsilon tolerance"),
+    TypeRule::with_comment("RE", "RE", "LO", "3.14159", "2.71828", "Exact IEEE-754 not-equals (matches COSY behavior)"),
     TypeRule::with_comment("ST", "ST", "LO", "'hello'", "'world'", "String not-equals"),
     TypeRule::with_comment("LO", "LO", "LO", "TRUE", "FALSE", "Logical not-equals"),
 ];
 
+static NEQ_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(NEQ_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    NEQ_MAP.get_or_init(|| build_type_registry(NEQ_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyNeq<Rhs = Self> {
@@ -42,11 +47,11 @@ pub trait RosyNeq<Rhs = Self> {
     fn rosy_neq(self, rhs: Rhs) -> Result<Self::Output>;
 }
 
-// RE # RE (with epsilon tolerance)
+// RE # RE (exact IEEE-754, matches COSY behavior)
 impl RosyNeq<&RE> for &RE {
     type Output = LO;
     fn rosy_neq(self, rhs: &RE) -> Result<Self::Output> {
-        Ok((self - rhs).abs() >= f64::EPSILON)
+        Ok(self != rhs)
     }
 }
 

--- a/rosy/src/rosy_lib/operators/pow.rs
+++ b/rosy/src/rosy_lib/operators/pow.rs
@@ -13,6 +13,8 @@
 use anyhow::Result;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, VE, DA, CD};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 use crate::rosy_lib::core::polval::{da_powi, cd_powi};
 
@@ -26,9 +28,12 @@ pub const POW_REGISTRY: &[TypeRule] = &[
     TypeRule::new("CD", "RE", "CD", "CD(1)", "2"),
 ];
 
+static POW_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(POW_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    POW_MAP.get_or_init(|| build_type_registry(POW_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosyPow<Rhs = Self> {

--- a/rosy/src/rosy_lib/operators/sub.rs
+++ b/rosy/src/rosy_lib/operators/sub.rs
@@ -17,6 +17,8 @@ use anyhow::Result;
 use num_complex::Complex64;
 use crate::rosy_lib::RosyType;
 use crate::rosy_lib::{RE, CM, VE, DA, CD};
+use std::sync::OnceLock;
+use std::collections::HashMap;
 use crate::rosy_lib::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for subtraction operator.
@@ -49,9 +51,12 @@ pub const SUB_REGISTRY: &[TypeRule] = &[
     TypeRule::new("CD", "CD", "CD", "DA(1)+CM(1&2)*DA(2)", "DA(3)+CM(5&6)*DA(4)"),
 ];
 
+static SUB_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
+
 pub fn get_return_type(lhs: &RosyType, rhs: &RosyType) -> Option<RosyType> {
-    let registry = build_type_registry(SUB_REGISTRY);
-    registry.get(&(*lhs, *rhs)).copied()
+    SUB_MAP.get_or_init(|| build_type_registry(SUB_REGISTRY))
+        .get(&(*lhs, *rhs))
+        .copied()
 }
 
 pub trait RosySub<Rhs = Self> {
@@ -152,6 +157,8 @@ impl RosySub<&RE> for &VE {
 impl RosySub<&VE> for &VE {
     type Output = VE;
     fn rosy_sub(self, other: &VE) -> Result<Self::Output> {
+        anyhow::ensure!(self.len() == other.len(),
+            "Vector length mismatch in subtraction: {} vs {}", self.len(), other.len());
         Ok(self.iter()
             .zip(other.iter())
             .map(|(x, y)| x - y)


### PR DESCRIPTION
## Summary

- **OnceLock type registries**: All 13 `get_return_type` functions now use `static OnceLock<HashMap>` — eliminates a fresh HashMap allocation on every type-check call
- **`ok_or_else` in `type_of`**: All 15 transpiler operator `type_of` functions pre-bind `left_type`/`right_type` locals and use `ok_or_else(||...)` — previously, successful type checks redundantly re-invoked `type_of` on both children to build the error message string
- **`lazy_static` removed**: `PRATT_PARSER` migrated to `std::sync::LazyLock`; `lazy_static` dependency dropped from both `Cargo.toml` files
- **VE length-mismatch guard**: `VE+VE`, `VE-VE`, `VE*VE`, `VE/VE` now `bail!` on mismatched lengths — COSY hard-errors (`LENGTH NOT MATCHED`); Rosy was silently truncating via `.zip()`
- **Equality correctness**: `RosyEq<&RE>` and `RosyNeq<&RE>` changed from `f64::EPSILON` tolerance to exact IEEE-754 `==`/`!=`, matching COSY behavior (confirmed: `0.1+0.2 = 0.3` is `FALSE` in both)
- **Wrong error message**: `MultExpr::transpile` error said "Cannot add" — fixed to "Cannot multiply"
- **COSY test artifacts**: `and_op/test.fox` and `or_op/test.fox` used `AND`/`OR` keywords that COSY rejects; corrected to use `*`/`+`; added missing `or_op/cosy_output.txt`
- **`pow.rs` merge**: Rebased cleanly on top of PR #94's `DA^RE`/`CD^RE` additions

## Test plan

- [ ] `cargo build --release` passes with no warnings
- [ ] `cargo test` — all 21 tests pass
- [ ] Verify VE length-mismatch produces a runtime error in a transpiled program
- [ ] Verify `0.1 + 0.2 = 0.3` evaluates to `FALSE` (matching COSY)
- [ ] Verify `DA^RE` and `CD^RE` from PR #94 still work correctly after pow.rs conflict resolution