### PR TITLE
chore: ponytail audit — drop dead type tables and no-op trait boilerplate (1.7.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "rosy"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/rosy-lib/src/core.rs
+++ b/rosy-lib/src/core.rs
@@ -13,7 +13,6 @@ pub mod mblock;
 pub mod mtree;
 pub mod polval;
 pub mod recst;
-pub mod reran;
 pub mod rkco;
 pub mod rng;
 pub mod mem_serial;

--- a/rosy-lib/src/core/daprv.rs
+++ b/rosy-lib/src/core/daprv.rs
@@ -265,7 +265,7 @@ pub fn rosy_datrn(
 /// - `result`:  output DA array
 pub fn rosy_daplu(da_in: &Vec<DA>, var_idx: usize, c: f64, result: &mut Vec<DA>) -> Result<()> {
     use rustc_hash::FxHashMap;
-    use crate::taylor::MAX_VARS;
+    
 
     let config = get_config().context("DAPLU requires DA to be initialized (call OV first)")?;
     let var_0idx = var_idx

--- a/rosy-lib/src/core/file_io.rs
+++ b/rosy-lib/src/core/file_io.rs
@@ -9,7 +9,6 @@ use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::sync::Mutex;
 use anyhow::{Result, Context, bail};
 
-use crate::core::display::RosyDisplay;
 
 /// Global file handle registry, mapping unit numbers to open file handles.
 static FILE_REGISTRY: Mutex<Option<HashMap<u64, FileHandle>>> = Mutex::new(None);
@@ -18,8 +17,8 @@ static FILE_REGISTRY: Mutex<Option<HashMap<u64, FileHandle>>> = Mutex::new(None)
 struct FileHandle {
     reader: Option<BufReader<File>>,
     writer: Option<BufWriter<File>>,
-    path: String,
-    is_binary: bool,
+    _path: String,
+    _is_binary: bool,
 }
 
 fn ensure_registry() {
@@ -80,8 +79,8 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
             registry.insert(unit_num, FileHandle {
                 reader: Some(BufReader::new(read_handle)),
                 writer: Some(BufWriter::new(file)),
-                path: filename.to_string(),
-                is_binary,
+                _path: filename.to_string(),
+                _is_binary: is_binary,
             });
         }
         "replace" => {
@@ -96,8 +95,8 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
             registry.insert(unit_num, FileHandle {
                 reader: None,
                 writer: Some(BufWriter::new(file)),
-                path: filename.to_string(),
-                is_binary,
+                _path: filename.to_string(),
+                _is_binary: is_binary,
             });
         }
         "old" => {
@@ -108,8 +107,8 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
             registry.insert(unit_num, FileHandle {
                 reader: Some(BufReader::new(file)),
                 writer: None,
-                path: filename.to_string(),
-                is_binary,
+                _path: filename.to_string(),
+                _is_binary: is_binary,
             });
         }
         "new" => {
@@ -122,8 +121,8 @@ fn open_file_impl(unit: f64, filename: &str, status: &str, is_binary: bool) -> R
             registry.insert(unit_num, FileHandle {
                 reader: None,
                 writer: Some(BufWriter::new(file)),
-                path: filename.to_string(),
-                is_binary,
+                _path: filename.to_string(),
+                _is_binary: is_binary,
             });
         }
         _ => bail!("Unknown file status '{}' for OPENF/OPENFB. Expected 'unknown', 'old', 'new', or 'replace'.", status),

--- a/rosy-lib/src/core/lev.rs
+++ b/rosy-lib/src/core/lev.rs
@@ -11,7 +11,7 @@
 //! columns i and i+1 of V contain the real and imaginary parts of
 //! the corresponding eigenvector (COSY convention).
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 /// Compute eigenvalues and eigenvectors of the n×n leading submatrix of `matrix`.
 ///

--- a/rosy-lib/src/core/mtree.rs
+++ b/rosy-lib/src/core/mtree.rs
@@ -12,7 +12,7 @@
 //! This matches COSY's MTREE output format so programs ported from COSY
 //! that use MTREE for fast map evaluation will work correctly.
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use crate::taylor::{self, DA};
 
 /// Build the tree representation of a DA vector.

--- a/rosy-lib/src/core/reran.rs
+++ b/rosy-lib/src/core/reran.rs
@@ -1,5 +1,0 @@
-/// Returns a pseudo-random f64 in [-1, 1], matching COSY's RERAN behavior.
-/// Draws from the global seeded RNG (see [`super::rng`]).
-pub fn rosy_reran() -> f64 {
-    super::rng::rosy_reran()
-}

--- a/rosy-lib/src/intrinsics.rs
+++ b/rosy-lib/src/intrinsics.rs
@@ -86,20 +86,3 @@ pub use erf::RosyERF;
 pub use werf::RosyWERF;
 pub use position::RosyPOSITION;
 
-/// Represents a parsed intrinsic type rule from the source code.
-#[derive(Debug, Clone)]
-pub struct IntrinsicTypeRule {
-    pub input: &'static str,
-    pub result: &'static str,
-    pub test_val: &'static str,
-}
-impl IntrinsicTypeRule {
-    /// Create a new intrinsic type rule.
-    pub const fn new(
-        input: &'static str,
-        result: &'static str,
-        test_val: &'static str
-    ) -> Self {
-        Self { input, result, test_val }
-    }
-}

--- a/rosy-lib/src/intrinsics/abs.rs
+++ b/rosy-lib/src/intrinsics/abs.rs
@@ -1,35 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA, CD};
-
-/// Type registry for ABS intrinsic function.
-///
-/// ABS computes the absolute value. Supports:
-/// - RE -> RE (f64::abs)
-/// - CM -> RE (Complex modulus / norm)
-/// - VE -> RE (sum of absolute values of elements)
-/// - DA -> RE (max absolute value among coefficients)
-pub const ABS_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "RE", "CM(3.0&4.0)"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "RE", "CD(1)"),
-];
 
 /// Get the return type of ABS for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        m.insert(RosyType::RE(), RosyType::RE());
-        m.insert(RosyType::CM(), RosyType::RE());
-        m.insert(RosyType::VE(), RosyType::RE());
-        m.insert(RosyType::DA(), RosyType::RE());
-        m.insert(RosyType::CD(), RosyType::RE());
-        m
-    };
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the absolute value of Rosy data types.

--- a/rosy-lib/src/intrinsics/acos.rs
+++ b/rosy-lib/src/intrinsics/acos.rs
@@ -1,38 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA};
-
-/// Type registry for ACOS intrinsic function.
-///
-/// According to COSY INFINITY manual, ACOS supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: CM is NOT supported for ACOS in COSY.
-pub const ACOS_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "0.5"),
-    IntrinsicTypeRule::new("VE", "VE", "0.1&0.2&0.3"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
 
 /// Get the return type of ACOS for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing arccosine of Rosy data types.
@@ -73,8 +49,6 @@ impl RosyACOS for DA {
 /// Uses the identity acos(x) = pi/2 - asin(x), so derivatives of acos are
 /// the negative of the derivatives of asin (for n >= 1).
 fn da_acos(da: &DA) -> anyhow::Result<DA> {
-    use crate::taylor::DACoefficient;
-
     let rt = crate::taylor::get_runtime()?;
     let nocut = rt.config.max_order as usize;
 

--- a/rosy-lib/src/intrinsics/asin.rs
+++ b/rosy-lib/src/intrinsics/asin.rs
@@ -1,38 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA};
-
-/// Type registry for ASIN intrinsic function.
-///
-/// According to COSY INFINITY manual, ASIN supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: CM is NOT supported for ASIN in COSY.
-pub const ASIN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "0.5"),
-    IntrinsicTypeRule::new("VE", "VE", "0.1&0.2&0.3"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
 
 /// Get the return type of ASIN for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing arcsine of Rosy data types.
@@ -70,8 +46,6 @@ impl RosyASIN for DA {
 
 /// Compute arcsine of a DA object using Taylor series composition.
 fn da_asin(da: &DA) -> anyhow::Result<DA> {
-    use crate::taylor::DACoefficient;
-
     let rt = crate::taylor::get_runtime()?;
     let nocut = rt.config.max_order as usize;
 

--- a/rosy-lib/src/intrinsics/atan.rs
+++ b/rosy-lib/src/intrinsics/atan.rs
@@ -1,38 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA};
-
-/// Type registry for ATAN intrinsic function.
-///
-/// According to COSY INFINITY manual, ATAN supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: CM is NOT supported for ATAN in COSY.
-pub const ATAN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
 
 /// Get the return type of ATAN for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing arctangent of Rosy data types.
@@ -73,7 +49,7 @@ impl RosyATAN for DA {
 /// Differentiating n times: (1+x²)*f^(n+1) + 2*n*x*f^(n) + n*(n-1)*f^(n-1) = 0
 /// => f^(n+1) = -[2*n*x*f^(n) + n*(n-1)*f^(n-1)] / (1+x²)
 fn da_atan(da: &DA) -> anyhow::Result<DA> {
-    use crate::taylor::DACoefficient;
+    
 
     let rt = crate::taylor::get_runtime()?;
     let nocut = rt.config.max_order as usize;

--- a/rosy-lib/src/intrinsics/cm.rs
+++ b/rosy-lib/src/intrinsics/cm.rs
@@ -1,25 +1,15 @@
-use std::collections::HashMap;
-
 use crate::RosyType;
 use crate::{RE, CM, VE, CD};
 use anyhow::{Result, ensure};
 
-pub fn get_return_type ( lhs: &RosyType ) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec!(
-            (RosyType::RE(), RosyType::CM()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::CM()),
-            (RosyType::CD(), RosyType::CM()),
-        );
-        for (left, result) in all {
-            m.insert(left, result);
-        }
-        m
-    };
-
-    registry.get(&*lhs).copied()
+pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::CM()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::CM()),
+        t if *t == RosyType::CD() => Some(RosyType::CM()),
+        _ => None,
+    }
 }
 
 

--- a/rosy-lib/src/intrinsics/cmplx.rs
+++ b/rosy-lib/src/intrinsics/cmplx.rs
@@ -1,37 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, DA, CD};
-
-/// Type registry for CMPLX intrinsic function (convert to complex).
-///
-/// According to COSY INFINITY manual, CMPLX supports:
-/// - RE -> CM
-/// - CM -> CM (identity)
-pub const CMPLX_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "CM", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("DA", "CD", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of CMPLX for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::CM()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::DA(), RosyType::CD()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::CM()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::DA() => Some(RosyType::CD()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for converting Rosy data types to complex.

--- a/rosy-lib/src/intrinsics/conj.rs
+++ b/rosy-lib/src/intrinsics/conj.rs
@@ -1,35 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, CD};
-
-/// Type registry for CONJ intrinsic function (complex conjugate).
-///
-/// According to COSY INFINITY manual, CONJ supports:
-/// - RE -> RE (identity, real numbers are their own conjugate)
-/// - CM -> CM (complex conjugate)
-pub const CONJ_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of CONJ for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for computing complex conjugate of Rosy data types.
@@ -58,7 +37,7 @@ impl RosyCONJ for CM {
 impl RosyCONJ for CD {
     type Output = CD;
     fn rosy_conj(&self) -> anyhow::Result<Self::Output> {
-        use crate::taylor::{DACoefficient, Monomial};
+        use crate::taylor::DACoefficient;
         use num_complex::Complex64;
         let mut result = CD::from_coeff(Complex64::zero());
         for (monomial, coeff) in self.coeffs_iter() {

--- a/rosy-lib/src/intrinsics/cons.rs
+++ b/rosy-lib/src/intrinsics/cons.rs
@@ -1,42 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA, CD};
-
-/// Type registry for CONS intrinsic function.
-///
-/// According to COSY INFINITY manual, CONS supports:
-/// - RE -> RE (identity)
-/// - CM -> CM (identity)
-/// - VE -> RE (max abs value)
-/// - DA -> RE (constant part)
-/// - CD -> CM (constant part of complex DA)
-pub const CONS_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "CM", "CD(1)"),
-];
 
 /// Get the return type of CONS for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-            (RosyType::CD(), RosyType::CM()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::CM()),
+        _ => None,
+    }
 }
 
 /// Trait for extracting the constant part of Rosy data types.

--- a/rosy-lib/src/intrinsics/cos.rs
+++ b/rosy-lib/src/intrinsics/cos.rs
@@ -1,41 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA, CD};
-
-/// Type registry for COS intrinsic function.
-///
-/// According to COSY INFINITY manual, COS supports:
-/// - RE -> RE
-/// - CM -> CM (complex cos)
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-pub const COS_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of COS for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for computing cosine of Rosy data types.
@@ -108,7 +83,7 @@ fn da_cos(da: &DA) -> anyhow::Result<DA> {
 
 /// Compute cosine of a CD object using Horner's method.
 fn cd_cos(cd: &CD) -> anyhow::Result<CD> {
-    use crate::taylor::DACoefficient;
+    
     use num_complex::Complex64;
 
     let config = crate::taylor::get_config()?;

--- a/rosy-lib/src/intrinsics/cosh.rs
+++ b/rosy-lib/src/intrinsics/cosh.rs
@@ -1,39 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA};
-
-/// Type registry for COSH intrinsic function.
-///
-/// According to COSY INFINITY manual, COSH supports:
-/// - RE -> RE
-/// - CM -> CM (complex hyperbolic cosine)
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-pub const COSH_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
 
 /// Get the return type of COSH for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing hyperbolic cosine of Rosy data types.

--- a/rosy-lib/src/intrinsics/erf.rs
+++ b/rosy-lib/src/intrinsics/erf.rs
@@ -1,33 +1,13 @@
-use std::collections::HashMap;
-
 use crate::{DA, RE};
-use crate::{IntrinsicTypeRule, RosyType};
-
-/// Type registry for ERF intrinsic function.
-///
-/// According to COSY INFINITY manual, ERF supports:
-/// - RE -> RE (real error function)
-/// - DA -> DA (Taylor composition via derivative recurrence)
-pub const ERF_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
+use crate::RosyType;
 
 /// Get the return type of ERF for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the real error function of Rosy data types.

--- a/rosy-lib/src/intrinsics/exp.rs
+++ b/rosy-lib/src/intrinsics/exp.rs
@@ -1,41 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA, CD};
-
-/// Type registry for EXP intrinsic function.
-/// 
-/// According to COSY INFINITY manual, EXP supports:
-/// - RE -> RE
-/// - CM -> CM
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-pub const EXP_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of EXP for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the exponential of Rosy data types.
@@ -109,7 +84,7 @@ fn da_exp(da: &DA) -> anyhow::Result<DA> {
 
 /// Compute exponential of a CD object using Horner's method.
 fn cd_exp(cd: &CD) -> anyhow::Result<CD> {
-    use crate::taylor::DACoefficient;
+    
     use num_complex::Complex64;
 
     let config = crate::taylor::get_config()?;

--- a/rosy-lib/src/intrinsics/imag_fn.rs
+++ b/rosy-lib/src/intrinsics/imag_fn.rs
@@ -1,38 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, DA, CD};
-
-/// Type registry for IMAG intrinsic function.
-///
-/// According to COSY INFINITY manual, IMAG supports:
-/// - RE -> RE (returns 0.0)
-/// - CM -> RE (imaginary part of complex)
-/// - DA -> DA (returns zero DA)
-pub const IMAG_FN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "RE", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "DA", "CD(1)"),
-];
 
 /// Get the return type of IMAG for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::DA(), RosyType::DA()),
-            (RosyType::CD(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        t if *t == RosyType::CD() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the imaginary part of Rosy data types.

--- a/rosy-lib/src/intrinsics/int_fn.rs
+++ b/rosy-lib/src/intrinsics/int_fn.rs
@@ -1,27 +1,13 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE};
-
-/// Type registry for INT intrinsic function.
-///
-/// INT truncates toward zero. Supports:
-/// - RE -> RE (f64::trunc)
-/// - VE -> VE (elementwise trunc)
-pub const INT_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.7"),
-    IntrinsicTypeRule::new("VE", "VE", "1.7&2.3&3.9"),
-];
 
 /// Get the return type of INT for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        m.insert(RosyType::RE(), RosyType::RE());
-        m.insert(RosyType::VE(), RosyType::VE());
-        m
-    };
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        _ => None,
+    }
 }
 
 /// Trait for truncating Rosy data types toward zero.

--- a/rosy-lib/src/intrinsics/isrt.rs
+++ b/rosy-lib/src/intrinsics/isrt.rs
@@ -1,39 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA};
-
-/// Type registry for ISRT intrinsic function (inverse square root, x^(-1/2)).
-///
-/// According to COSY INFINITY manual, ISRT supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: DA test value uses `4.0 + DA(1)` (constant part = 4, linear = x1)
-/// because ISRT requires a positive constant part for the binomial expansion.
-pub const ISRT_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "4.0"),
-    IntrinsicTypeRule::new("VE", "VE", "4.0&9.0&16.0"),
-    IntrinsicTypeRule::new("DA", "DA", "4.0 + DA(1)"),
-];
 
 /// Get the return type of ISRT for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing inverse square root of Rosy data types.
@@ -73,7 +48,7 @@ impl RosyISRT for DA {
 /// (1 + u)^alpha = sum_{n=0}^{N} C(alpha, n) * u^n
 /// C(alpha, n) = alpha*(alpha-1)*...*(alpha-n+1) / n!
 fn da_isrt(da: &DA) -> anyhow::Result<DA> {
-    use crate::taylor::DACoefficient;
+    
 
     let rt = crate::taylor::get_runtime()?;
     let nocut = rt.config.max_order as usize;

--- a/rosy-lib/src/intrinsics/isrt3.rs
+++ b/rosy-lib/src/intrinsics/isrt3.rs
@@ -1,39 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA};
-
-/// Type registry for ISRT3 intrinsic function (x^(-3/2)).
-///
-/// According to COSY INFINITY manual, ISRT3 supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: DA test value uses `4.0 + DA(1)` (constant part = 4, linear = x1)
-/// because ISRT3 requires a positive constant part for the binomial expansion.
-pub const ISRT3_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "4.0"),
-    IntrinsicTypeRule::new("VE", "VE", "4.0&9.0&16.0"),
-    IntrinsicTypeRule::new("DA", "DA", "4.0 + DA(1)"),
-];
 
 /// Get the return type of ISRT3 for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing x^(-3/2) of Rosy data types.
@@ -72,7 +47,7 @@ impl RosyISRT3 for DA {
 /// f^alpha = f0^alpha * (1 + u)^alpha  where u = (f - f0) / f0
 /// (1 + u)^alpha = sum_{n=0}^{N} C(alpha, n) * u^n
 fn da_isrt3(da: &DA) -> anyhow::Result<DA> {
-    use crate::taylor::DACoefficient;
+    
 
     let rt = crate::taylor::get_runtime()?;
     let nocut = rt.config.max_order as usize;

--- a/rosy-lib/src/intrinsics/length.rs
+++ b/rosy-lib/src/intrinsics/length.rs
@@ -1,50 +1,18 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, ST, LO, CM, VE, DA, CD};
-
-/// Type registry for LENGTH intrinsic function.
-/// 
-/// According to COSY INFINITY manual, LENGTH returns RE for all types:
-/// - RE -> RE
-/// - ST -> RE  
-/// - LO -> RE
-/// - CM -> RE
-/// - VE -> RE
-/// - DA -> RE
-/// - CD -> RE
-/// - GR -> RE (not implemented yet)
-pub const LENGTH_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("ST", "RE", "\"Hello\""),
-    IntrinsicTypeRule::new("LO", "RE", "TRUE"),
-    IntrinsicTypeRule::new("CM", "RE", "1.5&2.5"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "1.5+DA(1)"),
-    IntrinsicTypeRule::new("CD", "RE", "CM(1.5&2.5)+CD(1)"),
-];
-
 
 /// Get the return type of LENGTH for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::ST(), RosyType::RE()),
-            (RosyType::LO(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-            (RosyType::CD(), RosyType::RE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::ST() => Some(RosyType::RE()),
+        t if *t == RosyType::LO() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for getting the LENGTH (memory size in 8-byte blocks) of Rosy data types.

--- a/rosy-lib/src/intrinsics/lo.rs
+++ b/rosy-lib/src/intrinsics/lo.rs
@@ -1,23 +1,12 @@
-use std::collections::HashMap;
-
 use crate::RosyType;
-use crate::{RE, CM, VE, LO, ST, DA, CD};
-use crate::core::display::RosyDisplay;
+use crate::{RE, LO};
 
-pub fn get_return_type ( lhs: &RosyType ) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec!(
-            (RosyType::RE(), RosyType::LO()),
-            (RosyType::LO(), RosyType::LO()),
-        );
-        for (left, result) in all {
-            m.insert(left, result);
-        }
-        m
-    };
-
-    registry.get(&*lhs).copied()
+pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::LO()),
+        t if *t == RosyType::LO() => Some(RosyType::LO()),
+        _ => None,
+    }
 }           
 
 /// Trait for converting Rosy data types to strings

--- a/rosy-lib/src/intrinsics/log.rs
+++ b/rosy-lib/src/intrinsics/log.rs
@@ -1,43 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA};
-
-/// Type registry for LOG intrinsic function.
-///
-/// According to COSY INFINITY manual, LOG supports:
-/// - RE -> RE
-/// - CM -> CM
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: DA test value uses DA(1) + 1.0 (= 1 + x) instead of DA(1) (= x)
-/// because LOG requires a non-zero constant part. DA(1) has constant part 0,
-/// which would cause a domain error (ln(0) is undefined).
-pub const LOG_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1) + 1.0"),
-];
 
 /// Get the return type of LOG for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the natural logarithm of Rosy data types.

--- a/rosy-lib/src/intrinsics/ltrim.rs
+++ b/rosy-lib/src/intrinsics/ltrim.rs
@@ -1,12 +1,4 @@
 use crate::ST;
-use super::IntrinsicTypeRule;
-
-/// Type registry for LTRIM intrinsic function.
-///
-/// LTRIM removes leading space characters from a string.
-pub const LTRIM_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("ST", "ST", "'  hello  '"),
-];
 
 /// Get the return type of LTRIM for a given input type.
 pub fn get_return_type(input: &crate::RosyType) -> Option<crate::RosyType> {

--- a/rosy-lib/src/intrinsics/nint.rs
+++ b/rosy-lib/src/intrinsics/nint.rs
@@ -1,27 +1,13 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE};
-
-/// Type registry for NINT intrinsic function.
-///
-/// NINT rounds to the nearest integer. Supports:
-/// - RE -> RE (f64::round)
-/// - VE -> VE (elementwise round)
-pub const NINT_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.7"),
-    IntrinsicTypeRule::new("VE", "VE", "1.7&2.3&3.9"),
-];
 
 /// Get the return type of NINT for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        m.insert(RosyType::RE(), RosyType::RE());
-        m.insert(RosyType::VE(), RosyType::VE());
-        m
-    };
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        _ => None,
+    }
 }
 
 /// Trait for rounding Rosy data types to the nearest integer.

--- a/rosy-lib/src/intrinsics/norm.rs
+++ b/rosy-lib/src/intrinsics/norm.rs
@@ -1,36 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA, CD};
-
-/// Type registry for NORM intrinsic function.
-///
-/// According to COSY INFINITY manual, NORM supports:
-/// - VE -> RE (L1 norm = sum of absolute values of components)
-/// - DA -> RE (max coefficient abs, i.e. max norm)
-/// - CD -> RE (max coefficient abs of complex DA)
-pub const NORM_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "RE", "CD(1)"),
-];
 
 /// Get the return type of NORM for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-            (RosyType::CD(), RosyType::RE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the norm of Rosy data types.

--- a/rosy-lib/src/intrinsics/re_convert.rs
+++ b/rosy-lib/src/intrinsics/re_convert.rs
@@ -1,42 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, ST, DA};
-
-/// Type registry for RE() conversion function.
-///
-/// According to COSY INFINITY manual, RE() supports:
-/// - RE -> RE (identity)
-/// - ST -> RE (parse string as f64)
-/// - CM -> RE (extracts real part)
-/// - VE -> RE (average)
-/// - DA -> RE (constant part)
-pub const RE_CONVERT_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("ST", "RE", "\"3.14\""),
-    IntrinsicTypeRule::new("CM", "RE", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "DA(1)"),
-];
 
 /// Get the return type of RE() for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::ST(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::ST() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for converting Rosy data types to real (RE).

--- a/rosy-lib/src/intrinsics/real_fn.rs
+++ b/rosy-lib/src/intrinsics/real_fn.rs
@@ -1,38 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, DA, CD};
-
-/// Type registry for REAL intrinsic function.
-///
-/// According to COSY INFINITY manual, REAL supports:
-/// - RE -> RE (identity)
-/// - CM -> RE (real part of complex)
-/// - DA -> DA (identity)
-pub const REAL_FN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "RE", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "DA", "CD(1)"),
-];
 
 /// Get the return type of REAL for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::DA(), RosyType::DA()),
-            (RosyType::CD(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        t if *t == RosyType::CD() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the real part of Rosy data types.

--- a/rosy-lib/src/intrinsics/sin.rs
+++ b/rosy-lib/src/intrinsics/sin.rs
@@ -1,42 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA, CD};
-
-/// Type registry for SIN intrinsic function.
-/// 
-/// According to COSY INFINITY manual, SIN supports:
-/// - RE -> RE
-/// - CM -> CM (complex sin)
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-/// - CD -> CD (complex Taylor composition)
-pub const SIN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of SIN for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for computing sine of Rosy data types.
@@ -109,7 +83,7 @@ fn da_sin(da: &DA) -> anyhow::Result<DA> {
 
 /// Compute sine of a CD object using Horner's method for Taylor composition.
 fn cd_sin(cd: &CD) -> anyhow::Result<CD> {
-    use crate::taylor::DACoefficient;
+    
     use num_complex::Complex64;
 
     let config = crate::taylor::get_config()?;

--- a/rosy-lib/src/intrinsics/sinh.rs
+++ b/rosy-lib/src/intrinsics/sinh.rs
@@ -1,39 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA};
-
-/// Type registry for SINH intrinsic function.
-///
-/// According to COSY INFINITY manual, SINH supports:
-/// - RE -> RE
-/// - CM -> CM (complex hyperbolic sine)
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-pub const SINH_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
 
 /// Get the return type of SINH for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing hyperbolic sine of Rosy data types.

--- a/rosy-lib/src/intrinsics/sqr.rs
+++ b/rosy-lib/src/intrinsics/sqr.rs
@@ -1,42 +1,16 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA, CD};
-
-/// Type registry for SQR intrinsic function.
-/// 
-/// SQR computes the square (x²). Supports:
-/// - RE -> RE
-/// - CM -> CM
-/// - VE -> VE (elementwise)
-/// - DA -> DA
-/// - CD -> CD
-pub const SQR_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of SQR for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the square of Rosy data types.

--- a/rosy-lib/src/intrinsics/sqrt.rs
+++ b/rosy-lib/src/intrinsics/sqrt.rs
@@ -1,42 +1,15 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, VE, DA};
-
-/// Type registry for SQRT intrinsic function.
-///
-/// According to COSY INFINITY manual, SQRT supports:
-/// - RE -> RE
-/// - CM -> CM
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: DA test value uses EXP(DA(1)) to ensure a positive constant part,
-/// which is required for the binomial series expansion of sqrt.
-pub const SQRT_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "4.0"),
-    IntrinsicTypeRule::new("CM", "CM", "CM(3.0&4.0)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.0&4.0&9.0"),
-    IntrinsicTypeRule::new("DA", "DA", "EXP(DA(1))"),
-];
 
 /// Get the return type of SQRT for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the square root of Rosy data types.
@@ -85,7 +58,7 @@ impl RosySQRT for DA {
 ///
 /// Requires: f0 = constant part of the DA > 0 (sqrt is not analytic at 0).
 fn da_sqrt(da: &DA) -> anyhow::Result<DA> {
-    use crate::taylor::DACoefficient;
+    
 
     let rt = crate::taylor::get_runtime()?;
     let nocut = rt.config.max_order as usize;

--- a/rosy-lib/src/intrinsics/st.rs
+++ b/rosy-lib/src/intrinsics/st.rs
@@ -1,28 +1,18 @@
-use std::collections::HashMap;
-
 use crate::RosyType;
 use crate::{RE, CM, VE, LO, ST, DA, CD};
 use crate::core::display::RosyDisplay;
 
-pub fn get_return_type ( lhs: &RosyType ) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec!(
-            (RosyType::RE(), RosyType::ST()),
-            (RosyType::ST(), RosyType::ST()),
-            (RosyType::LO(), RosyType::ST()),
-            (RosyType::CM(), RosyType::ST()),
-            (RosyType::VE(), RosyType::ST()),
-            (RosyType::DA(), RosyType::ST()),
-            (RosyType::CD(), RosyType::ST()),
-        );
-        for (left, result) in all {
-            m.insert(left, result);
-        }
-        m
-    };
-
-    registry.get(&*lhs).copied()
+pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::ST()),
+        t if *t == RosyType::ST() => Some(RosyType::ST()),
+        t if *t == RosyType::LO() => Some(RosyType::ST()),
+        t if *t == RosyType::CM() => Some(RosyType::ST()),
+        t if *t == RosyType::VE() => Some(RosyType::ST()),
+        t if *t == RosyType::DA() => Some(RosyType::ST()),
+        t if *t == RosyType::CD() => Some(RosyType::ST()),
+        _ => None,
+    }
 }           
 
 /// Trait for converting Rosy data types to strings

--- a/rosy-lib/src/intrinsics/tan.rs
+++ b/rosy-lib/src/intrinsics/tan.rs
@@ -1,38 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
-use crate::{RE, VE, DA, CD};
-
-/// Type registry for TAN intrinsic function.
-/// 
-/// According to COSY INFINITY manual, TAN supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-/// 
-/// Note: CM is NOT supported for TAN in COSY.
-pub const TAN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
+use crate::RosyType;
+use crate::{RE, VE, DA};
 
 /// Get the return type of TAN for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the tangent of Rosy data types.

--- a/rosy-lib/src/intrinsics/tanh.rs
+++ b/rosy-lib/src/intrinsics/tanh.rs
@@ -1,38 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, VE, DA};
-
-/// Type registry for TANH intrinsic function.
-///
-/// According to COSY INFINITY manual, TANH supports:
-/// - RE -> RE
-/// - VE -> VE (elementwise)
-/// - DA -> DA (Taylor composition)
-///
-/// Note: CM is NOT supported for TANH in COSY.
-pub const TANH_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "DA", "DA(1)"),
-];
 
 /// Get the return type of TANH for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::VE(), RosyType::VE()),
-            (RosyType::DA(), RosyType::DA()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        t if *t == RosyType::DA() => Some(RosyType::DA()),
+        _ => None,
+    }
 }
 
 /// Trait for computing hyperbolic tangent of Rosy data types.

--- a/rosy-lib/src/intrinsics/trim.rs
+++ b/rosy-lib/src/intrinsics/trim.rs
@@ -1,12 +1,4 @@
 use crate::ST;
-use super::IntrinsicTypeRule;
-
-/// Type registry for TRIM intrinsic function.
-///
-/// TRIM removes trailing space characters from a string.
-pub const TRIM_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("ST", "ST", "'  hello  '"),
-];
 
 /// Get the return type of TRIM for a given input type.
 pub fn get_return_type(input: &crate::RosyType) -> Option<crate::RosyType> {

--- a/rosy-lib/src/intrinsics/type_fn.rs
+++ b/rosy-lib/src/intrinsics/type_fn.rs
@@ -1,43 +1,19 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, CM, ST, LO, VE, DA, CD};
-
-/// Type registry for TYPE intrinsic function.
-///
-/// Returns the COSY type code as RE:
-/// - RE=1, ST=2, LO=3, CM=4, VE=5, DA=6, CD=7, GR=8
-pub const TYPE_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("ST", "RE", "'test'"),
-    IntrinsicTypeRule::new("LO", "RE", "TRUE"),
-    IntrinsicTypeRule::new("CM", "RE", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "DA(1)"),
-    IntrinsicTypeRule::new("CD", "RE", "CD(1)"),
-];
 
 /// Get the return type of TYPE for a given input type.
 /// TYPE always returns RE regardless of input.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::CD(), RosyType::RE()),
-            (RosyType::ST(), RosyType::RE()),
-            (RosyType::LO(), RosyType::RE()),
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::RE()),
+        t if *t == RosyType::ST() => Some(RosyType::RE()),
+        t if *t == RosyType::LO() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for returning the COSY type code of Rosy data types.

--- a/rosy-lib/src/intrinsics/varmem.rs
+++ b/rosy-lib/src/intrinsics/varmem.rs
@@ -1,48 +1,18 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, ST, LO, CM, VE, DA, CD};
-
-/// Type registry for VARMEM intrinsic function.
-///
-/// According to COSY INFINITY manual, VARMEM returns RE for all types:
-/// - RE -> RE
-/// - ST -> RE
-/// - LO -> RE
-/// - CM -> RE
-/// - VE -> RE
-/// - DA -> RE
-/// - CD -> RE
-pub const VARMEM_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("ST", "RE", "\"Hello\""),
-    IntrinsicTypeRule::new("LO", "RE", "TRUE"),
-    IntrinsicTypeRule::new("CM", "RE", "1.5&2.5"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "1.5+DA(1)"),
-    IntrinsicTypeRule::new("CD", "RE", "CM(1.5&2.5)+CD(1)"),
-];
 
 /// Get the return type of VARMEM for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::ST(), RosyType::RE()),
-            (RosyType::LO(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-            (RosyType::CD(), RosyType::RE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::ST() => Some(RosyType::RE()),
+        t if *t == RosyType::LO() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for getting the memory address of Rosy data types.

--- a/rosy-lib/src/intrinsics/varpoi.rs
+++ b/rosy-lib/src/intrinsics/varpoi.rs
@@ -1,51 +1,18 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{RE, ST, LO, CM, VE, DA, CD};
-
-/// Type registry for VARPOI intrinsic function.
-///
-/// According to COSY INFINITY manual, VARPOI returns RE for all types:
-/// - RE -> RE
-/// - ST -> RE
-/// - LO -> RE
-/// - CM -> RE
-/// - VE -> RE
-/// - DA -> RE
-/// - CD -> RE
-///
-/// In Rosy, VARPOI returns the Rust pointer address cast to f64,
-/// identical in behavior to VARMEM (Rust has no Fortran-style pointer/memory distinction).
-pub const VARPOI_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "RE", "1.5"),
-    IntrinsicTypeRule::new("ST", "RE", "\"Hello\""),
-    IntrinsicTypeRule::new("LO", "RE", "TRUE"),
-    IntrinsicTypeRule::new("CM", "RE", "1.5&2.5"),
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-    IntrinsicTypeRule::new("DA", "RE", "1.5+DA(1)"),
-    IntrinsicTypeRule::new("CD", "RE", "CM(1.5&2.5)+CD(1)"),
-];
 
 /// Get the return type of VARPOI for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::RE()),
-            (RosyType::ST(), RosyType::RE()),
-            (RosyType::LO(), RosyType::RE()),
-            (RosyType::CM(), RosyType::RE()),
-            (RosyType::VE(), RosyType::RE()),
-            (RosyType::DA(), RosyType::RE()),
-            (RosyType::CD(), RosyType::RE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::RE()),
+        t if *t == RosyType::ST() => Some(RosyType::RE()),
+        t if *t == RosyType::LO() => Some(RosyType::RE()),
+        t if *t == RosyType::CM() => Some(RosyType::RE()),
+        t if *t == RosyType::VE() => Some(RosyType::RE()),
+        t if *t == RosyType::DA() => Some(RosyType::RE()),
+        t if *t == RosyType::CD() => Some(RosyType::RE()),
+        _ => None,
+    }
 }
 
 /// Trait for getting the pointer address of Rosy data types.

--- a/rosy-lib/src/intrinsics/ve_convert.rs
+++ b/rosy-lib/src/intrinsics/ve_convert.rs
@@ -1,36 +1,14 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{CM, RE, VE};
-
-/// Type registry for VE() conversion function.
-///
-/// VE() supports:
-/// - RE -> VE (single-element vector)
-/// - CM -> VE (two-vector of real, imaginary parts)
-/// - VE -> VE (identity)
-pub const VE_CONVERT_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("RE", "VE", "1.5"),
-    IntrinsicTypeRule::new("CM", "VE", "CM(1.5&2.5)"),
-    IntrinsicTypeRule::new("VE", "VE", "1.5&2.5&3.5"),
-];
 
 /// Get the return type of VE() for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::RE(), RosyType::VE()),
-            (RosyType::CM(), RosyType::VE()),
-            (RosyType::VE(), RosyType::VE()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::RE() => Some(RosyType::VE()),
+        t if *t == RosyType::CM() => Some(RosyType::VE()),
+        t if *t == RosyType::VE() => Some(RosyType::VE()),
+        _ => None,
+    }
 }
 
 /// Trait for converting Rosy data types to vectors (VE).

--- a/rosy-lib/src/intrinsics/vmin.rs
+++ b/rosy-lib/src/intrinsics/vmin.rs
@@ -1,12 +1,5 @@
 use crate::{RE, VE};
-use crate::{IntrinsicTypeRule, RosyType};
-
-/// Type registry for VMIN intrinsic function.
-///
-/// VMIN returns the minimum element of a vector.
-pub const VMIN_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("VE", "RE", "1.5&2.5&3.5"),
-];
+use crate::RosyType;
 
 /// Get the return type of VMIN for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {

--- a/rosy-lib/src/intrinsics/werf.rs
+++ b/rosy-lib/src/intrinsics/werf.rs
@@ -1,33 +1,13 @@
-use std::collections::HashMap;
-
-use crate::{IntrinsicTypeRule, RosyType};
+use crate::RosyType;
 use crate::{CM, CD};
-
-/// Type registry for WERF intrinsic function (Faddeeva function).
-///
-/// According to COSY INFINITY manual, WERF supports:
-/// - CM -> CM (complex error function w)
-/// - CD -> CD (Taylor composition)
-pub const WERF_REGISTRY: &[IntrinsicTypeRule] = &[
-    IntrinsicTypeRule::new("CM", "CM", "CM(0.5&1.5)"),
-    IntrinsicTypeRule::new("CD", "CD", "CD(1)"),
-];
 
 /// Get the return type of WERF for a given input type.
 pub fn get_return_type(input: &RosyType) -> Option<RosyType> {
-    let registry: HashMap<RosyType, RosyType> = {
-        let mut m = HashMap::new();
-        let all = vec![
-            (RosyType::CM(), RosyType::CM()),
-            (RosyType::CD(), RosyType::CD()),
-        ];
-        for (input_type, result_type) in all {
-            m.insert(input_type, result_type);
-        }
-        m
-    };
-
-    registry.get(input).copied()
+    match input {
+        t if *t == RosyType::CM() => Some(RosyType::CM()),
+        t if *t == RosyType::CD() => Some(RosyType::CD()),
+        _ => None,
+    }
 }
 
 /// Trait for computing the Faddeeva function of Rosy data types.
@@ -120,7 +100,7 @@ fn faddeeva_w(z: CM) -> CM {
 /// For n=0: g_1 = -2*f0*g_0 + 2i/sqrt(pi)
 /// For n>=1: (n+1)*g_{n+1} = -2*f0*g_n - 2*g_{n-1}
 fn cd_werf(cd: &CD) -> anyhow::Result<CD> {
-    use crate::taylor::DACoefficient;
+    
     use num_complex::Complex64;
 
     let config = crate::taylor::get_config()?;

--- a/rosy-lib/src/lib.rs
+++ b/rosy-lib/src/lib.rs
@@ -1,6 +1,4 @@
 #![cfg_attr(feature = "nightly-simd", feature(portable_simd))]
-#![allow(unused_imports)]
-#![allow(dead_code)]
 
 //! # Rosy Runtime Library
 //!
@@ -140,62 +138,24 @@ impl std::fmt::Display for RosyType {
     }
 }
 impl RosyType {
-    pub fn new(base_type: RosyBaseType, dimensions: usize) -> Self {
-        RosyType {
-            base_type,
-            dimensions,
-        }
+    pub const fn new(base_type: RosyBaseType, dimensions: usize) -> Self {
+        RosyType { base_type, dimensions }
     }
 
     #[allow(non_snake_case)]
-    pub fn RE() -> Self {
-        RosyType {
-            base_type: RosyBaseType::RE,
-            dimensions: 0,
-        }
-    }
+    pub const fn RE() -> Self { Self::new(RosyBaseType::RE, 0) }
     #[allow(non_snake_case)]
-    pub fn ST() -> Self {
-        RosyType {
-            base_type: RosyBaseType::ST,
-            dimensions: 0,
-        }
-    }
+    pub const fn ST() -> Self { Self::new(RosyBaseType::ST, 0) }
     #[allow(non_snake_case)]
-    pub fn LO() -> Self {
-        RosyType {
-            base_type: RosyBaseType::LO,
-            dimensions: 0,
-        }
-    }
+    pub const fn LO() -> Self { Self::new(RosyBaseType::LO, 0) }
     #[allow(non_snake_case)]
-    pub fn CM() -> Self {
-        RosyType {
-            base_type: RosyBaseType::CM,
-            dimensions: 0,
-        }
-    }
+    pub const fn CM() -> Self { Self::new(RosyBaseType::CM, 0) }
     #[allow(non_snake_case)]
-    pub fn VE() -> Self {
-        RosyType {
-            base_type: RosyBaseType::VE,
-            dimensions: 0,
-        }
-    }
+    pub const fn VE() -> Self { Self::new(RosyBaseType::VE, 0) }
     #[allow(non_snake_case)]
-    pub fn DA() -> Self {
-        RosyType {
-            base_type: RosyBaseType::DA,
-            dimensions: 0,
-        }
-    }
+    pub const fn DA() -> Self { Self::new(RosyBaseType::DA, 0) }
     #[allow(non_snake_case)]
-    pub fn CD() -> Self {
-        RosyType {
-            base_type: RosyBaseType::CD,
-            dimensions: 0,
-        }
-    }
+    pub const fn CD() -> Self { Self::new(RosyBaseType::CD, 0) }
 
     /// Returns true if this type implements Copy in Rust (cheap to duplicate).
     /// RE (f64), LO (bool), CM (Complex64) are Copy at dimension 0.

--- a/rosy-lib/src/operators.rs
+++ b/rosy-lib/src/operators.rs
@@ -38,41 +38,14 @@ use crate::{RosyType, RosyBaseType};
 /// Defines a type compatibility rule for an operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TypeRule {
-    /// Left-hand side type
     pub lhs: &'static str,
-    /// Right-hand side type
     pub rhs: &'static str,
-    /// Result type
     pub result: &'static str,
-    /// Test values for lhs and rhs
-    pub lhs_test_val: &'static str,
-    pub rhs_test_val: &'static str,
-    /// Optional comment for documentation
-    pub comment: &'static str,
 }
 
 impl TypeRule {
-    /// Create a new type rule without a comment.
-    pub const fn new(
-        lhs: &'static str,
-        rhs: &'static str,
-        result: &'static str,
-        lhs_test_val: &'static str,
-        rhs_test_val: &'static str
-    ) -> Self {
-        Self { lhs, rhs, result, lhs_test_val, rhs_test_val, comment: "" }
-    }
-    
-    /// Create a new type rule with a comment.
-    pub const fn with_comment(
-        lhs: &'static str,
-        rhs: &'static str,
-        result: &'static str,
-        lhs_test_val: &'static str,
-        rhs_test_val: &'static str,
-        comment: &'static str
-    ) -> Self {
-        Self { lhs, rhs, result, lhs_test_val, rhs_test_val, comment }
+    pub const fn new(lhs: &'static str, rhs: &'static str, result: &'static str) -> Self {
+        Self { lhs, rhs, result }
     }
 }
 

--- a/rosy-lib/src/operators/add.rs
+++ b/rosy-lib/src/operators/add.rs
@@ -30,26 +30,26 @@ use crate::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`add.fox`)
 /// - Integration tests
 pub const ADD_REGISTRY: &[TypeRule] = &[
-    TypeRule::new("RE", "RE", "RE", "-2", "1"),
-    TypeRule::new("RE", "CM", "CM", "2", "CM(0&1)"),
-    TypeRule::with_comment("RE", "VE", "VE", "1", "1&2", "Add Real componentwise"),
-    TypeRule::new("RE", "DA", "DA", "3", "DA(1)"),
-    TypeRule::new("RE", "CD", "CD", "4", "DA(1)+CM(0&1)*DA(2)"),
-    TypeRule::with_comment("LO", "LO", "LO", "LO(1)", "LO(0)", "Logical OR"),
-    TypeRule::new("CM", "RE", "CM", "CM(0&1)", "5"),
-    TypeRule::new("CM", "CM", "CM", "CM(2&3)", "CM(4&5)"),
-    TypeRule::new("CM", "DA", "CD", "CM(0&1)", "DA(1)"),
-    TypeRule::new("CM", "CD", "CD", "CM(0&1)", "DA(1)+CM(2&3)*DA(2)"),
-    TypeRule::with_comment("VE", "RE", "VE", "1&2", "6", "Add Real componentwise"),
-    TypeRule::with_comment("VE", "VE", "VE", "1&2", "3&4", "Add componentwise"),
-    TypeRule::new("DA", "RE", "DA", "DA(1)", "7"),
-    TypeRule::new("DA", "CM", "CD", "DA(1)", "CM(0&1)"),
-    TypeRule::new("DA", "DA", "DA", "DA(2)", "DA(3)"),
-    TypeRule::new("DA", "CD", "CD", "DA(1)", "DA(1)+CM(0&1)*DA(2)"),
-    TypeRule::new("CD", "RE", "CD", "DA(1)+CM(0&1)*DA(2)", "-8"),
-    TypeRule::new("CD", "CM", "CD", "DA(1)+CM(0&1)*DA(2)", "CM(2&3)"),
-    TypeRule::new("CD", "DA", "CD", "DA(1)+CM(0&1)*DA(2)", "DA(3)"),
-    TypeRule::new("CD", "CD", "CD", "DA(1)+CM(0&1)*DA(2)", "DA(3)+CM(4&5)*DA(6)"),
+    TypeRule::new("RE", "RE", "RE"),
+    TypeRule::new("RE", "CM", "CM"),
+    TypeRule::new("RE", "VE", "VE"),
+    TypeRule::new("RE", "DA", "DA"),
+    TypeRule::new("RE", "CD", "CD"),
+    TypeRule::new("LO", "LO", "LO"),
+    TypeRule::new("CM", "RE", "CM"),
+    TypeRule::new("CM", "CM", "CM"),
+    TypeRule::new("CM", "DA", "CD"),
+    TypeRule::new("CM", "CD", "CD"),
+    TypeRule::new("VE", "RE", "VE"),
+    TypeRule::new("VE", "VE", "VE"),
+    TypeRule::new("DA", "RE", "DA"),
+    TypeRule::new("DA", "CM", "CD"),
+    TypeRule::new("DA", "DA", "DA"),
+    TypeRule::new("DA", "CD", "CD"),
+    TypeRule::new("CD", "RE", "CD"),
+    TypeRule::new("CD", "CM", "CD"),
+    TypeRule::new("CD", "DA", "CD"),
+    TypeRule::new("CD", "CD", "CD"),
 ];
 
 static ADD_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
@@ -189,7 +189,7 @@ impl RosyAdd<&CD> for &CM {
 impl RosyAdd<&CM> for &DA {
     type Output = CD;
     fn rosy_add(self, other: &CM) -> Result<Self::Output> {
-        use num_complex::Complex64;
+        
         // Create CD from the complex number
         let cm_cd = CD::complex_constant(*other);
 

--- a/rosy-lib/src/operators/concat.rs
+++ b/rosy-lib/src/operators/concat.rs
@@ -33,21 +33,21 @@ use crate::operators::{TypeRule, build_type_registry};
 /// See manual.md Section A.2 "& (Concatenation)" for the authoritative list.
 /// GR (Graphics) type is not yet implemented in Rosy.
 pub const CONCAT_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "VE", "1", "1", "Concatenate two Reals to a Vector"),
-    TypeRule::with_comment("RE", "VE", "VE", "1", "1&2&3", "Prepend a Real to the left of a Vector"),
-    TypeRule::with_comment("ST", "ST", "ST", "'He'", "'ya!'", "Concatenate two Strings"),
-    TypeRule::with_comment("VE", "RE", "VE", "1&2", "3", "Append a Real to the right of a Vector"),
-    TypeRule::with_comment("VE", "VE", "VE", "1&2", "3&4", "Concatenate two Vectors"),
+    TypeRule::new("RE", "RE", "VE"),
+    TypeRule::new("RE", "VE", "VE"),
+    TypeRule::new("ST", "ST", "ST"),
+    TypeRule::new("VE", "RE", "VE"),
+    TypeRule::new("VE", "VE", "VE"),
     // DA concatenation — builds vectors of Taylor series (phase-space maps)
-    TypeRule::with_comment("DA", "DA", "DA1", "DA(1)", "DA(2)", "Concatenate two DAs to a DA vector"),
-    TypeRule::with_comment("DA", "DA1", "DA1", "DA(1)", "DA(1)&DA(2)", "Prepend a DA to the left of a DA vector"),
-    TypeRule::with_comment("DA1", "DA", "DA1", "DA(1)&DA(2)", "DA(3)", "Append a DA to the right of a DA vector"),
-    TypeRule::with_comment("DA1", "DA1", "DA1", "DA(1)&DA(2)", "DA(3)&DA(4)", "Concatenate two DA vectors"),
+    TypeRule::new("DA", "DA", "DA1"),
+    TypeRule::new("DA", "DA1", "DA1"),
+    TypeRule::new("DA1", "DA", "DA1"),
+    TypeRule::new("DA1", "DA1", "DA1"),
     // CD concatenation — builds vectors of complex Taylor series
-    TypeRule::with_comment("CD", "CD", "CD1", "CD(1)", "CD(2)", "Concatenate two CDs to a CD vector"),
-    TypeRule::with_comment("CD", "CD1", "CD1", "CD(1)", "CD(1)&CD(2)", "Prepend a CD to the left of a CD vector"),
-    TypeRule::with_comment("CD1", "CD", "CD1", "CD(1)&CD(2)", "CD(3)", "Append a CD to the right of a CD vector"),
-    TypeRule::with_comment("CD1", "CD1", "CD1", "CD(1)&CD(2)", "CD(3)&CD(4)", "Concatenate two CD vectors"),
+    TypeRule::new("CD", "CD", "CD1"),
+    TypeRule::new("CD", "CD1", "CD1"),
+    TypeRule::new("CD1", "CD", "CD1"),
+    TypeRule::new("CD1", "CD1", "CD1"),
     // GR & GR => GR is in COSY but GR type not implemented in Rosy yet
 ];
 

--- a/rosy-lib/src/operators/div.rs
+++ b/rosy-lib/src/operators/div.rs
@@ -29,25 +29,25 @@ use crate::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`div.fox`)
 /// - Integration tests
 pub const DIV_REGISTRY: &[TypeRule] = &[
-    TypeRule::new("RE", "RE", "RE", "6", "2"),
-    TypeRule::new("RE", "CM", "CM", "8", "CM(2&3)"),
-    TypeRule::with_comment("RE", "VE", "VE", "10", "2&3", "Divide Real componentwise"),
-    TypeRule::new("RE", "DA", "DA", "12", "3+DA(1)"),
-    TypeRule::new("RE", "CD", "CD", "14", "2+DA(1)+CM(2&3)*DA(2)"),
-    TypeRule::new("CM", "RE", "CM", "CM(4&5)", "3"),
-    TypeRule::new("CM", "CM", "CM", "CM(6&7)", "CM(8&9)"),
-    TypeRule::new("CM", "DA", "CD", "CM(2&3)", "2+DA(1)"),
-    TypeRule::new("CM", "CD", "CD", "CM(2&3)", "3+DA(1)+CM(4&5)*DA(2)"),
-    TypeRule::with_comment("VE", "RE", "VE", "4&5", "4", "Divide by Real componentwise"),
-    TypeRule::with_comment("VE", "VE", "VE", "6&8", "7&9", "Divide componentwise"),
-    TypeRule::new("DA", "RE", "DA", "DA(1)", "5"),
-    TypeRule::new("DA", "CM", "CD", "DA(1)", "CM(2&3)"),
-    TypeRule::new("DA", "DA", "DA", "2+DA(2)", "1+DA(3)"),
-    TypeRule::new("DA", "CD", "CD", "DA(1)", "2+DA(2)+CM(2&3)*DA(3)"),
-    TypeRule::new("CD", "RE", "CD", "DA(1)+CM(2&3)*DA(2)", "6"),
-    TypeRule::new("CD", "CM", "CD", "DA(1)+CM(2&3)*DA(2)", "CM(4&5)"),
-    TypeRule::new("CD", "DA", "CD", "DA(1)+CM(2&3)*DA(2)", "3+DA(3)"),
-    TypeRule::new("CD", "CD", "CD", "1+DA(1)+CM(2&3)*DA(2)", "2+DA(3)+CM(6&7)*DA(4)"),
+    TypeRule::new("RE", "RE", "RE"),
+    TypeRule::new("RE", "CM", "CM"),
+    TypeRule::new("RE", "VE", "VE"),
+    TypeRule::new("RE", "DA", "DA"),
+    TypeRule::new("RE", "CD", "CD"),
+    TypeRule::new("CM", "RE", "CM"),
+    TypeRule::new("CM", "CM", "CM"),
+    TypeRule::new("CM", "DA", "CD"),
+    TypeRule::new("CM", "CD", "CD"),
+    TypeRule::new("VE", "RE", "VE"),
+    TypeRule::new("VE", "VE", "VE"),
+    TypeRule::new("DA", "RE", "DA"),
+    TypeRule::new("DA", "CM", "CD"),
+    TypeRule::new("DA", "DA", "DA"),
+    TypeRule::new("DA", "CD", "CD"),
+    TypeRule::new("CD", "RE", "CD"),
+    TypeRule::new("CD", "CM", "CD"),
+    TypeRule::new("CD", "DA", "CD"),
+    TypeRule::new("CD", "CD", "CD"),
 ];
 
 static DIV_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
@@ -219,7 +219,7 @@ impl RosyDiv<&RE> for &CD {
 impl RosyDiv<&CM> for &CD {
     type Output = CD;
     fn rosy_div(self, other: &CM) -> Result<Self::Output> {
-        use num_complex::Complex64;
+        
         self / *other
     }
 }

--- a/rosy-lib/src/operators/eq.rs
+++ b/rosy-lib/src/operators/eq.rs
@@ -29,9 +29,9 @@ use crate::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`eq.fox`)
 /// - Integration tests
 pub const EQ_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "3.14159", "3.14159", "Exact IEEE-754 equality (matches COSY behavior)"),
-    TypeRule::with_comment("ST", "ST", "LO", "'hello'", "'hello'", "String equality"),
-    TypeRule::with_comment("LO", "LO", "LO", "TRUE", "TRUE", "Logical equality"),
+    TypeRule::new("RE", "RE", "LO"),
+    TypeRule::new("ST", "ST", "LO"),
+    TypeRule::new("LO", "LO", "LO"),
 ];
 
 static EQ_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/extract.rs
+++ b/rosy-lib/src/operators/extract.rs
@@ -34,15 +34,15 @@ use crate::taylor::monomial::Monomial;
 /// This registry matches COSY INFINITY's | operator capabilities exactly,
 /// as documented in manual.md Section A.2.
 pub const EXTRACT_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("ST", "RE", "ST", "'test'", "2", "Extract i-th character"),
-    TypeRule::with_comment("ST", "VE", "ST", "'test'", "2&3", "Extract substring by range"),
-    TypeRule::with_comment("CM", "RE", "RE", "CM(3&4)", "1", "Extract real part"),
-    TypeRule::with_comment("VE", "RE", "RE", "1&2", "2", "Extract i-th component"),
-    TypeRule::with_comment("VE", "VE", "VE", "1&2&3", "2&3", "Extract subvector by range"),
-    TypeRule::with_comment("DA", "RE", "RE", "DA(1)", "1", "Extract 1D DA coefficient for supplied exponent"),
-    TypeRule::with_comment("DA", "VE", "RE", "DA(1)", "0&1", "Extract DA coefficient by exponent vector"),
-    TypeRule::with_comment("CD", "RE", "CM", "CD(1)", "1", "Extract 1D CD coefficient for supplied exponent"),
-    TypeRule::with_comment("CD", "VE", "CM", "CD(1)", "0&1", "Extract CD coefficient by exponent vector"),
+    TypeRule::new("ST", "RE", "ST"),
+    TypeRule::new("ST", "VE", "ST"),
+    TypeRule::new("CM", "RE", "RE"),
+    TypeRule::new("VE", "RE", "RE"),
+    TypeRule::new("VE", "VE", "VE"),
+    TypeRule::new("DA", "RE", "RE"),
+    TypeRule::new("DA", "VE", "RE"),
+    TypeRule::new("CD", "RE", "CM"),
+    TypeRule::new("CD", "VE", "CM"),
 ];
 
 static EXTRACT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/gt.rs
+++ b/rosy-lib/src/operators/gt.rs
@@ -13,8 +13,8 @@ use crate::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for greater-than operator.
 pub const GT_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "2.0", "1.0", "Numeric greater-than"),
-    TypeRule::with_comment("ST", "ST", "LO", "'banana'", "'apple'", "Lexicographic ordering"),
+    TypeRule::new("RE", "RE", "LO"),
+    TypeRule::new("ST", "ST", "LO"),
 ];
 
 static GT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/gte.rs
+++ b/rosy-lib/src/operators/gte.rs
@@ -15,8 +15,8 @@ use crate::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for greater-than-or-equal operator.
 pub const GTE_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "2.0", "2.0", "Numeric greater-than-or-equal"),
-    TypeRule::with_comment("ST", "ST", "LO", "'banana'", "'banana'", "Lexicographic ordering"),
+    TypeRule::new("RE", "RE", "LO"),
+    TypeRule::new("ST", "ST", "LO"),
 ];
 
 static GTE_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/lt.rs
+++ b/rosy-lib/src/operators/lt.rs
@@ -13,8 +13,8 @@ use crate::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for less-than operator.
 pub const LT_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "1.0", "2.0", "Numeric less-than"),
-    TypeRule::with_comment("ST", "ST", "LO", "'apple'", "'banana'", "Lexicographic ordering"),
+    TypeRule::new("RE", "RE", "LO"),
+    TypeRule::new("ST", "ST", "LO"),
 ];
 
 static LT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/lte.rs
+++ b/rosy-lib/src/operators/lte.rs
@@ -15,8 +15,8 @@ use crate::operators::{TypeRule, build_type_registry};
 
 /// Type compatibility registry for less-than-or-equal operator.
 pub const LTE_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "2.0", "2.0", "Numeric less-than-or-equal"),
-    TypeRule::with_comment("ST", "ST", "LO", "'apple'", "'apple'", "Lexicographic ordering"),
+    TypeRule::new("RE", "RE", "LO"),
+    TypeRule::new("ST", "ST", "LO"),
 ];
 
 static LTE_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/mult.rs
+++ b/rosy-lib/src/operators/mult.rs
@@ -29,26 +29,26 @@ use crate::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`mult.fox`)
 /// - Integration tests
 pub const MULT_REGISTRY: &[TypeRule] = &[
-    TypeRule::new("RE", "RE", "RE", "1", "1"),
-    TypeRule::new("RE", "CM", "CM", "2", "CM(0&1)"),
-    TypeRule::with_comment("RE", "VE", "VE", "1", "1&2", "Multiply Real componentwise"),
-    TypeRule::new("RE", "DA", "DA", "3", "DA(1)"),
-    TypeRule::new("RE", "CD", "CD", "4", "DA(1)+CM(0&1)*DA(2)"),
-    TypeRule::with_comment("LO", "LO", "LO", "LO(1)", "LO(0)", "Logical AND"),
-    TypeRule::new("CM", "RE", "CM", "CM(0&1)", "5"),
-    TypeRule::new("CM", "CM", "CM", "CM(2&3)", "CM(4&5)"),
-    TypeRule::new("CM", "DA", "CD", "CM(0&1)", "DA(1)"),
-    TypeRule::new("CM", "CD", "CD", "CM(0&1)", "DA(1)+CM(2&3)*DA(2)"),
-    TypeRule::with_comment("VE", "RE", "VE", "1&2", "6", "Multiply Real componentwise"),
-    TypeRule::with_comment("VE", "VE", "VE", "1&2", "3&4", "Multiply componentwise"),
-    TypeRule::new("DA", "RE", "DA", "DA(1)", "7"),
-    TypeRule::new("DA", "CM", "CD", "DA(1)", "CM(0&1)"),
-    TypeRule::new("DA", "DA", "DA", "DA(2)", "DA(3)"),
-    TypeRule::new("DA", "CD", "CD", "DA(1)", "DA(1)+CM(0&1)*DA(2)"),
-    TypeRule::new("CD", "RE", "CD", "DA(1)+CM(0&1)*DA(2)", "8"),
-    TypeRule::new("CD", "CM", "CD", "DA(1)+CM(0&1)*DA(2)", "CM(2&3)"),
-    TypeRule::new("CD", "DA", "CD", "DA(1)+CM(0&1)*DA(2)", "DA(3)"),
-    TypeRule::new("CD", "CD", "CD", "DA(1)+CM(0&1)*DA(2)", "DA(3)+CM(4&5)*DA(6)"),
+    TypeRule::new("RE", "RE", "RE"),
+    TypeRule::new("RE", "CM", "CM"),
+    TypeRule::new("RE", "VE", "VE"),
+    TypeRule::new("RE", "DA", "DA"),
+    TypeRule::new("RE", "CD", "CD"),
+    TypeRule::new("LO", "LO", "LO"),
+    TypeRule::new("CM", "RE", "CM"),
+    TypeRule::new("CM", "CM", "CM"),
+    TypeRule::new("CM", "DA", "CD"),
+    TypeRule::new("CM", "CD", "CD"),
+    TypeRule::new("VE", "RE", "VE"),
+    TypeRule::new("VE", "VE", "VE"),
+    TypeRule::new("DA", "RE", "DA"),
+    TypeRule::new("DA", "CM", "CD"),
+    TypeRule::new("DA", "DA", "DA"),
+    TypeRule::new("DA", "CD", "CD"),
+    TypeRule::new("CD", "RE", "CD"),
+    TypeRule::new("CD", "CM", "CD"),
+    TypeRule::new("CD", "DA", "CD"),
+    TypeRule::new("CD", "CD", "CD"),
 ];
 
 static MULT_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
@@ -226,7 +226,7 @@ impl RosyMult<&RE> for &CD {
 impl RosyMult<&CM> for &CD {
     type Output = CD;
     fn rosy_mult(self, other: &CM) -> Result<Self::Output> {
-        use num_complex::Complex64;
+        
         self * *other
     }
 }

--- a/rosy-lib/src/operators/neq.rs
+++ b/rosy-lib/src/operators/neq.rs
@@ -29,9 +29,9 @@ use crate::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`neq.fox`)
 /// - Integration tests
 pub const NEQ_REGISTRY: &[TypeRule] = &[
-    TypeRule::with_comment("RE", "RE", "LO", "3.14159", "2.71828", "Exact IEEE-754 not-equals (matches COSY behavior)"),
-    TypeRule::with_comment("ST", "ST", "LO", "'hello'", "'world'", "String not-equals"),
-    TypeRule::with_comment("LO", "LO", "LO", "TRUE", "FALSE", "Logical not-equals"),
+    TypeRule::new("RE", "RE", "LO"),
+    TypeRule::new("ST", "ST", "LO"),
+    TypeRule::new("LO", "LO", "LO"),
 ];
 
 static NEQ_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/pow.rs
+++ b/rosy-lib/src/operators/pow.rs
@@ -22,10 +22,10 @@ use crate::core::polval::{da_powi, cd_powi};
 ///
 /// This is the single source of truth for what type combinations are allowed.
 pub const POW_REGISTRY: &[TypeRule] = &[
-    TypeRule::new("RE", "RE", "RE", "2", "3"),
-    TypeRule::with_comment("VE", "RE", "VE", "1&2&3", "2", "Raise to Real power componentwise"),
-    TypeRule::new("DA", "RE", "DA", "DA(1)", "2"),
-    TypeRule::new("CD", "RE", "CD", "CD(1)", "2"),
+    TypeRule::new("RE", "RE", "RE"),
+    TypeRule::new("VE", "RE", "VE"),
+    TypeRule::new("DA", "RE", "DA"),
+    TypeRule::new("CD", "RE", "CD"),
 ];
 
 static POW_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();

--- a/rosy-lib/src/operators/sub.rs
+++ b/rosy-lib/src/operators/sub.rs
@@ -30,25 +30,25 @@ use crate::operators::{TypeRule, build_type_registry};
 /// - COSY test script (`sub.fox`)
 /// - Integration tests
 pub const SUB_REGISTRY: &[TypeRule] = &[
-    TypeRule::new("RE", "RE", "RE", "2", "1"),
-    TypeRule::new("RE", "CM", "CM", "3", "CM(1&2)"),
-    TypeRule::with_comment("RE", "VE", "VE", "5", "1&2", "Subtract componentwise from Real"),
-    TypeRule::new("RE", "DA", "DA", "4", "DA(1)"),
-    TypeRule::new("RE", "CD", "CD", "5", "DA(1)+CM(1&2)*DA(2)"),
-    TypeRule::new("CM", "RE", "CM", "CM(3&4)", "2"),
-    TypeRule::new("CM", "CM", "CM", "CM(5&6)", "CM(7&8)"),
-    TypeRule::new("CM", "DA", "CD", "CM(1&2)", "DA(1)"),
-    TypeRule::new("CM", "CD", "CD", "CM(1&2)", "DA(1)+CM(3&4)*DA(2)"),
-    TypeRule::with_comment("VE", "RE", "VE", "3&4", "3", "Subtract Real componentwise"),
-    TypeRule::with_comment("VE", "VE", "VE", "5&6", "7&8", "Subtract componentwise"),
-    TypeRule::new("DA", "RE", "DA", "DA(1)", "3"),
-    TypeRule::new("DA", "CM", "CD", "DA(1)", "CM(1&2)"),
-    TypeRule::new("DA", "DA", "DA", "DA(2)", "DA(3)"),
-    TypeRule::new("DA", "CD", "CD", "DA(1)", "DA(2)+CM(1&2)*DA(3)"),
-    TypeRule::new("CD", "RE", "CD", "DA(1)+CM(1&2)*DA(2)", "4"),
-    TypeRule::new("CD", "CM", "CD", "DA(1)+CM(1&2)*DA(2)", "CM(3&4)"),
-    TypeRule::new("CD", "DA", "CD", "DA(1)+CM(1&2)*DA(2)", "DA(3)"),
-    TypeRule::new("CD", "CD", "CD", "DA(1)+CM(1&2)*DA(2)", "DA(3)+CM(5&6)*DA(4)"),
+    TypeRule::new("RE", "RE", "RE"),
+    TypeRule::new("RE", "CM", "CM"),
+    TypeRule::new("RE", "VE", "VE"),
+    TypeRule::new("RE", "DA", "DA"),
+    TypeRule::new("RE", "CD", "CD"),
+    TypeRule::new("CM", "RE", "CM"),
+    TypeRule::new("CM", "CM", "CM"),
+    TypeRule::new("CM", "DA", "CD"),
+    TypeRule::new("CM", "CD", "CD"),
+    TypeRule::new("VE", "RE", "VE"),
+    TypeRule::new("VE", "VE", "VE"),
+    TypeRule::new("DA", "RE", "DA"),
+    TypeRule::new("DA", "CM", "CD"),
+    TypeRule::new("DA", "DA", "DA"),
+    TypeRule::new("DA", "CD", "CD"),
+    TypeRule::new("CD", "RE", "CD"),
+    TypeRule::new("CD", "CM", "CD"),
+    TypeRule::new("CD", "DA", "CD"),
+    TypeRule::new("CD", "CD", "CD"),
 ];
 
 static SUB_MAP: OnceLock<HashMap<(RosyType, RosyType), RosyType>> = OnceLock::new();
@@ -218,7 +218,7 @@ impl RosySub<&RE> for &CD {
 impl RosySub<&CM> for &CD {
     type Output = CD;
     fn rosy_sub(self, other: &CM) -> Result<Self::Output> {
-        use num_complex::Complex64;
+        
         self - *other
     }
 }

--- a/rosy-lib/src/taylor/da.rs
+++ b/rosy-lib/src/taylor/da.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use rustc_hash::FxHashMap;
 
 use super::{Monomial, MAX_VARS};
-use super::config::{get_runtime, get_config, MULT_INVALID, TaylorRuntime};
+use super::config::{get_runtime, MULT_INVALID, TaylorRuntime};
 
 // ============================================================================
 // Coefficient trait + pool

--- a/rosy/Cargo.toml
+++ b/rosy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosy"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2024"
 
 [lib]

--- a/rosy/src/errors.rs
+++ b/rosy/src/errors.rs
@@ -17,14 +17,12 @@ pub struct RosyError {
     /// Where in the source the error occurred.
     pub location: Option<SourceLocation>,
     /// The severity of the error.
-    pub severity: RosyErrorSeverity,
-}
+    pub severity: RosyErrorSeverity}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RosyErrorSeverity {
     Error,
-    Warning,
-}
+    Warning}
 
 impl RosyError {
     /// Create an error at a known source location.
@@ -32,8 +30,7 @@ impl RosyError {
         RosyError {
             message: message.into(),
             location: Some(location),
-            severity: RosyErrorSeverity::Error,
-        }
+            severity: RosyErrorSeverity::Error}
     }
 
     /// Create an error without a known location.
@@ -41,8 +38,7 @@ impl RosyError {
         RosyError {
             message: message.into(),
             location: None,
-            severity: RosyErrorSeverity::Error,
-        }
+            severity: RosyErrorSeverity::Error}
     }
 
     /// Create a warning at a known source location.
@@ -50,8 +46,7 @@ impl RosyError {
         RosyError {
             message: message.into(),
             location: Some(location),
-            severity: RosyErrorSeverity::Warning,
-        }
+            severity: RosyErrorSeverity::Warning}
     }
 }
 

--- a/rosy/src/lsp/analysis.rs
+++ b/rosy/src/lsp/analysis.rs
@@ -8,8 +8,7 @@ use crate::{
     errors::RosyError,
     program::Program,
     resolve::{GraphNode, TypeResolver, TypeSlot},
-    transpile::{TranspilationInputContext, Transpile},
-};
+    transpile::{TranspilationInputContext, Transpile}};
 use pest::Parser;
 use tower_lsp::lsp_types::*;
 
@@ -22,8 +21,7 @@ pub struct AnalysisResult {
     /// Value is the human-readable type string (e.g. "RE", "VE", "DA").
     pub variable_types: Vec<InlayHintData>,
     /// Semantic tokens for syntax highlighting via the LSP.
-    pub semantic_tokens: Vec<SemanticTokenData>,
-}
+    pub semantic_tokens: Vec<SemanticTokenData>}
 
 /// Data for a single semantic token.
 #[derive(Debug)]
@@ -31,8 +29,7 @@ pub struct SemanticTokenData {
     pub line: u32,
     pub start_col: u32,
     pub length: u32,
-    pub token_type: SemanticTokenType,
-}
+    pub token_type: SemanticTokenType}
 
 /// The token types we report to the editor.
 /// The index in LEGEND_TOKEN_TYPES must match what we register in capabilities.
@@ -44,8 +41,7 @@ pub enum SemanticTokenType {
     Variable,
     Number,
     String,
-    Comment,
-}
+    Comment}
 
 impl SemanticTokenType {
     pub fn index(self) -> u32 {
@@ -56,8 +52,7 @@ impl SemanticTokenType {
             SemanticTokenType::Variable => 3,
             SemanticTokenType::Number => 4,
             SemanticTokenType::String => 5,
-            SemanticTokenType::Comment => 6,
-        }
+            SemanticTokenType::Comment => 6}
     }
 }
 
@@ -81,8 +76,7 @@ pub struct InlayHintData {
     pub label: String,
     /// Where the type was inferred from (assignment RHS, function call, etc.)
     /// If present, the inlay hint label part becomes clickable, navigating here.
-    pub inferred_from: Option<InferredFromLocation>,
-}
+    pub inferred_from: Option<InferredFromLocation>}
 
 /// Where a type was inferred from — used for clickable inlay hint labels.
 #[derive(Debug)]
@@ -91,8 +85,7 @@ pub struct InferredFromLocation {
     pub line: u32,
     pub col: u32,
     /// Human-readable description of how the type was determined.
-    pub reason: String,
-}
+    pub reason: String}
 
 /// Extract an LSP Position from an anyhow error by downcasting to RosyError.
 ///
@@ -316,22 +309,18 @@ fn extract_inlay_hint(node: &GraphNode, hints: &mut Vec<InlayHintData>) {
         crate::resolve::ResolutionRule::Unresolved => (
             Some("could not be inferred".to_string()),
             node.declared_at.as_ref(),
-        ),
-    };
+        )};
 
     let inferred_from = match (reason, loc) {
         (Some(reason), Some(loc)) => Some(InferredFromLocation {
             line: loc.line.saturating_sub(1) as u32,
             col: loc.col.saturating_sub(1) as u32,
-            reason: format!("{} (line {}, col {})", reason, loc.line, loc.col),
-        }),
+            reason: format!("{} (line {}, col {})", reason, loc.line, loc.col)}),
         (Some(reason), None) => Some(InferredFromLocation {
             line: declared_at.line.saturating_sub(1) as u32,
             col: declared_at.col.saturating_sub(1) as u32,
-            reason,
-        }),
-        _ => None,
-    };
+            reason}),
+        _ => None};
 
     hints.push(InlayHintData {
         // SourceLocation uses 1-based line/col, LSP uses 0-based
@@ -340,8 +329,7 @@ fn extract_inlay_hint(node: &GraphNode, hints: &mut Vec<InlayHintData>) {
             hint_col.saturating_sub(1) as u32,
         ),
         label: format!("{resolved_type}"),
-        inferred_from,
-    });
+        inferred_from});
 }
 
 // ─── Semantic Tokenization ──────────────────────────────────────────────────
@@ -386,8 +374,7 @@ fn tokenize_source(source: &str) -> Vec<SemanticTokenData> {
                     line: line_num,
                     start_col: start as u32,
                     length: (i - start) as u32,
-                    token_type: SemanticTokenType::Comment,
-                });
+                    token_type: SemanticTokenType::Comment});
                 continue;
             }
 
@@ -412,8 +399,7 @@ fn tokenize_source(source: &str) -> Vec<SemanticTokenData> {
                     line: line_num,
                     start_col: start as u32,
                     length: (i - start) as u32,
-                    token_type: SemanticTokenType::String,
-                });
+                    token_type: SemanticTokenType::String});
                 continue;
             }
 
@@ -446,8 +432,7 @@ fn tokenize_source(source: &str) -> Vec<SemanticTokenData> {
                     line: line_num,
                     start_col: start as u32,
                     length: (i - start) as u32,
-                    token_type: SemanticTokenType::Number,
-                });
+                    token_type: SemanticTokenType::Number});
                 continue;
             }
 
@@ -486,8 +471,7 @@ fn tokenize_source(source: &str) -> Vec<SemanticTokenData> {
                     line: line_num,
                     start_col: start as u32,
                     length: (i - start) as u32,
-                    token_type,
-                });
+                    token_type});
                 continue;
             }
 
@@ -503,8 +487,7 @@ fn tokenize_source(source: &str) -> Vec<SemanticTokenData> {
 fn pest_error_to_diagnostic(error: &pest::error::Error<Rule>) -> Diagnostic {
     let (line, col): (usize, usize) = match error.line_col {
         pest::error::LineColLocation::Pos((line, col)) => (line, col),
-        pest::error::LineColLocation::Span((line, col), _) => (line, col),
-    };
+        pest::error::LineColLocation::Span((line, col), _) => (line, col)};
 
     Diagnostic {
         range: Range::new(
@@ -562,8 +545,7 @@ pub fn rosy_keywords() -> Vec<CompletionItem> {
                 },
                 documentation: Some(Documentation::MarkupContent(MarkupContent {
                     kind: MarkupKind::Markdown,
-                    value: format!("{detail}\n\n[Documentation]({base_url}/)"),
-                })),
+                    value: format!("{detail}\n\n[Documentation]({base_url}/)")})),
                 ..Default::default()
             }
         })

--- a/rosy/src/lsp/server.rs
+++ b/rosy/src/lsp/server.rs
@@ -17,26 +17,19 @@ struct DocumentState {
     /// The latest source text.
     text: String,
     /// The latest analysis result.
-    analysis: analysis::AnalysisResult,
-}
+    analysis: analysis::AnalysisResult}
 
 pub struct RosyLanguageServer {
     client: Client,
-    documents: Mutex<HashMap<Url, DocumentState>>,
-}
+    documents: Mutex<HashMap<Url, DocumentState>>}
 
 impl RosyLanguageServer {
     pub fn new(client: Client) -> Self {
-        // Ensure Rosy syntax mode is set (not COSY mode) for LSP usage
-        // Ignore the error if it's already been set
-        let _ = std::panic::catch_unwind(|| {
-            crate::syntax_config::set_cosy_syntax(false);
-        });
+        crate::syntax_config::set_cosy_syntax(false);
 
         RosyLanguageServer {
             client,
-            documents: Mutex::new(HashMap::new()),
-        }
+            documents: Mutex::new(HashMap::new())}
     }
 
     /// Run analysis on a document and publish diagnostics.
@@ -50,8 +43,7 @@ impl RosyLanguageServer {
             uri.clone(),
             DocumentState {
                 text,
-                analysis: result,
-            },
+                analysis: result},
         );
 
         self.client
@@ -84,8 +76,7 @@ impl LanguageServer for RosyLanguageServer {
                         SemanticTokensOptions {
                             legend: SemanticTokensLegend {
                                 token_types: analysis::LEGEND_TOKEN_TYPES.to_vec(),
-                                token_modifiers: vec![],
-                            },
+                                token_modifiers: vec![]},
                             full: Some(SemanticTokensFullOptions::Bool(true)),
                             range: None,
                             ..Default::default()
@@ -194,10 +185,8 @@ impl LanguageServer for RosyLanguageServer {
         Ok(hover_text.map(|text| Hover {
             contents: HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,
-                value: text,
-            }),
-            range: None,
-        }))
+                value: text}),
+            range: None}))
     }
 
     // ─── Inlay Hints ───────────────────────────────────────────────────
@@ -221,8 +210,7 @@ impl LanguageServer for RosyLanguageServer {
                 // Double-click inserts the type annotation at the hint position
                 let edit = TextEdit {
                     range: Range::new(h.position, h.position),
-                    new_text: format!(" {}", h.label),
-                };
+                    new_text: format!(" {}", h.label)};
 
                 InlayHint {
                     position: h.position,
@@ -232,13 +220,11 @@ impl LanguageServer for RosyLanguageServer {
                     tooltip: h.inferred_from.as_ref().map(|loc| {
                         InlayHintTooltip::MarkupContent(MarkupContent {
                             kind: MarkupKind::Markdown,
-                            value: format!("**{}** — {}", h.label, loc.reason),
-                        })
+                            value: format!("**{}** — {}", h.label, loc.reason)})
                     }),
                     padding_left: Some(true),
                     padding_right: Some(false),
-                    data: None,
-                }
+                    data: None}
             })
             .collect();
 
@@ -275,8 +261,7 @@ impl LanguageServer for RosyLanguageServer {
                 delta_start,
                 length: token.length,
                 token_type: token.token_type.index(),
-                token_modifiers_bitset: 0,
-            });
+                token_modifiers_bitset: 0});
 
             prev_line = token.line;
             prev_start = token.start_col;
@@ -284,8 +269,7 @@ impl LanguageServer for RosyLanguageServer {
 
         Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: None,
-            data: lsp_tokens,
-        })))
+            data: lsp_tokens})))
     }
 }
 

--- a/rosy/src/main.rs
+++ b/rosy/src/main.rs
@@ -275,7 +275,9 @@ fn compile_source(
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
     }
-    let output = cmd.output().context("Failed to spawn cargo build process")?;
+    let output = cmd
+        .output()
+        .context("Failed to spawn cargo build process")?;
     if !output.status.success() {
         if quiet {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/rosy/src/manifest.rs
+++ b/rosy/src/manifest.rs
@@ -28,15 +28,13 @@ use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 pub struct RosyToml {
-    pub package: PackageManifest,
-}
+    pub package: PackageManifest}
 
 #[derive(Debug, Deserialize)]
 pub struct PackageManifest {
     pub name: String,
     pub version: String,
-    pub rosy_version: String,
-}
+    pub rosy_version: String}
 
 impl RosyToml {
     /// Parse a `Rosy.toml` from disk at `<package_dir>/Rosy.toml`.

--- a/rosy/src/program.rs
+++ b/rosy/src/program.rs
@@ -18,8 +18,7 @@ use std::path::{Path, PathBuf};
 use crate::{
     ast::{CosyParser, FromRule, Rule},
     manifest::RosyToml,
-    program::statements::{SourceLocation, Statement},
-    resolve::*,
+    program::statements::Statement,
     transpile::*,
 };
 use anyhow::{Context, Error, Result, bail};
@@ -82,31 +81,7 @@ pub struct IncludeTracker {
 pub struct Program {
     pub statements: Vec<Statement>,
 }
-impl TranspileableStatement for Program {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
+impl TranspileableStatement for Program {}
 impl FromRule for Program {
     fn from_rule(pair: pest::iterators::Pair<Rule>) -> Result<Option<Program>> {
         Program::from_rule_with_includes(pair, None, &mut IncludeTracker::default())

--- a/rosy/src/program/expressions.rs
+++ b/rosy/src/program/expressions.rs
@@ -41,7 +41,7 @@ use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile
 use crate::{
     ast::{FromRule, PRATT_PARSER, Rule},
     resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot},
-    transpile::{ExprFunctionCallResult, TranspileableExpr, add_context_to_all},
+    transpile::{TranspileableExpr, add_context_to_all},
 };
 use rosy_lib::RosyType;
 use std::collections::HashSet;
@@ -477,7 +477,7 @@ impl TranspileableExpr for Expr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         self.inner.discover_expr_function_calls(resolver, ctx)
     }
     fn build_expr_recipe(

--- a/rosy/src/program/expressions/core/intrinsic_call.rs
+++ b/rosy/src/program/expressions/core/intrinsic_call.rs
@@ -5,10 +5,7 @@
 
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{
-    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-    TranspileableExpr, ValueKind,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind};
 use anyhow::{Context, Error, Result, bail};
 use rosy_lib::RosyType;
 use std::collections::{BTreeSet, HashSet};
@@ -110,13 +107,13 @@ impl TranspileableExpr for IntrinsicCallExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         for arg in &self.args {
             if let Err(e) = resolver.discover_expr_function_calls(arg, ctx) {
-                return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+                return Some(Err(e));
             }
         }
-        ExprFunctionCallResult::HasFunctionCalls { result: Ok(()) }
+        Some(Ok(()))
     }
 
     fn build_expr_recipe(

--- a/rosy/src/program/expressions/core/var_expr.rs
+++ b/rosy/src/program/expressions/core/var_expr.rs
@@ -33,10 +33,8 @@
 use super::variable_identifier::VariableIdentifier;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
-use crate::transpile::{
-    TranspilationInputContext, TranspilationOutput, Transpile, ValueKind, VariableScope,
-};
+use crate::transpile::TranspileableExpr;
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind, VariableScope};
 use anyhow::{Context, Error, Result, anyhow};
 use rosy_lib::RosyType;
 use std::collections::BTreeSet;
@@ -227,7 +225,7 @@ impl TranspileableExpr for VarExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         let ident = &self.identifier;
         let num_groups = ident.paren_groups.len();
         let is_var = ctx.variables.contains_key(&ident.name);
@@ -265,33 +263,31 @@ impl TranspileableExpr for VarExpr {
             // Recursively discover function calls in each argument expression
             for arg in &ident.paren_groups[0] {
                 if let Err(e) = resolver.discover_expr_function_calls(arg, ctx) {
-                    return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+                    return Some(Err(e));
                 }
             }
             // Wire up call-site argument type dependencies
-            ExprFunctionCallResult::HasFunctionCalls {
-                result: resolver.discover_call_site_deps(
+            Some(resolver.discover_call_site_deps(
                     &ident.name,
                     &ident.paren_groups[0],
                     true,
                     ctx,
-                ),
-            }
+                ),)
         } else {
             // Variable access — recurse into any index expressions
             for group in &ident.paren_groups {
                 for expr in group {
                     if let Err(e) = resolver.discover_expr_function_calls(expr, ctx) {
-                        return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+                        return Some(Err(e));
                     }
                 }
             }
             for expr in &ident.bracket_indices {
                 if let Err(e) = resolver.discover_expr_function_calls(expr, ctx) {
-                    return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+                    return Some(Err(e));
                 }
             }
-            ExprFunctionCallResult::NoFunctionCalls
+            None
         }
     }
     fn build_expr_recipe(

--- a/rosy/src/program/expressions/core/variable_identifier.rs
+++ b/rosy/src/program/expressions/core/variable_identifier.rs
@@ -164,13 +164,6 @@ impl TranspileableExpr for VariableIdentifier {
 
         Ok(var_type)
     }
-    fn discover_expr_function_calls(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::NoFunctionCalls
-    }
     fn build_expr_recipe(
         &self,
         _resolver: &TypeResolver,

--- a/rosy/src/program/expressions/kind.rs
+++ b/rosy/src/program/expressions/kind.rs
@@ -24,10 +24,7 @@ use super::pow::PowExpr;
 use super::types::cd::CDExpr;
 use super::types::da::DAExpr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{
-    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-    TranspileableExpr,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr};
 use anyhow::{Error, Result};
 use rosy_lib::RosyType;
 use std::collections::HashSet;
@@ -68,7 +65,7 @@ macro_rules! expr_kind {
                 &self,
                 resolver: &mut TypeResolver,
                 ctx: &ScopeContext,
-            ) -> ExprFunctionCallResult {
+            ) -> Option<Result<()>> {
                 match self {
                     $(Self::$var(v) => v.discover_expr_function_calls(resolver, ctx),)+
                 }

--- a/rosy/src/program/expressions/operators/arithmetic/add.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/add.rs
@@ -45,7 +45,7 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -83,13 +83,11 @@ impl TranspileableExpr for AddExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/arithmetic/div.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/div.rs
@@ -41,7 +41,7 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -78,13 +78,11 @@ impl TranspileableExpr for DivExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/arithmetic/mult.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/mult.rs
@@ -43,7 +43,7 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -80,13 +80,11 @@ impl TranspileableExpr for MultExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/arithmetic/sub.rs
+++ b/rosy/src/program/expressions/operators/arithmetic/sub.rs
@@ -41,7 +41,7 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -78,13 +78,11 @@ impl TranspileableExpr for SubExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/collection/concat.rs
+++ b/rosy/src/program/expressions/operators/collection/concat.rs
@@ -26,10 +26,7 @@
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{
-    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-    TranspileableExpr, ValueKind, VariableScope,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind, VariableScope};
 use anyhow::{Context, Error, Result};
 use rosy_lib::{RosyBaseType, RosyType};
 use std::collections::BTreeSet;
@@ -72,14 +69,14 @@ impl TranspileableExpr for ConcatExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
         if let Err(e) = resolver.discover_expr_function_calls(&self.right, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls { result: Ok(()) }
+        Some(Ok(()))
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/collection/derive.rs
+++ b/rosy/src/program/expressions/operators/collection/derive.rs
@@ -24,10 +24,7 @@
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{
-    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-    TranspileableExpr, ValueKind,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind};
 use anyhow::{Context as AnyhowContext, Error, Result};
 use rosy_lib::RosyType;
 use std::collections::{BTreeSet, HashSet};
@@ -87,13 +84,11 @@ impl TranspileableExpr for DeriveExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.object, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.index, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.index, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/collection/extract.rs
+++ b/rosy/src/program/expressions/operators/collection/extract.rs
@@ -33,7 +33,7 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result};
 use rosy_lib::RosyType;
@@ -77,13 +77,11 @@ impl TranspileableExpr for ExtractExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.object, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.index, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.index, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/eq.rs
+++ b/rosy/src/program/expressions/operators/comparison/eq.rs
@@ -27,7 +27,7 @@ use std::collections::HashSet;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -63,13 +63,11 @@ impl TranspileableExpr for EqExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/gt.rs
+++ b/rosy/src/program/expressions/operators/comparison/gt.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -61,13 +61,11 @@ impl TranspileableExpr for GtExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/gte.rs
+++ b/rosy/src/program/expressions/operators/comparison/gte.rs
@@ -27,7 +27,7 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -62,13 +62,11 @@ impl TranspileableExpr for GteExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/lt.rs
+++ b/rosy/src/program/expressions/operators/comparison/lt.rs
@@ -27,7 +27,7 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -62,13 +62,11 @@ impl TranspileableExpr for LtExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/lte.rs
+++ b/rosy/src/program/expressions/operators/comparison/lte.rs
@@ -27,7 +27,7 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -62,13 +62,11 @@ impl TranspileableExpr for LteExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/comparison/neq.rs
+++ b/rosy/src/program/expressions/operators/comparison/neq.rs
@@ -28,7 +28,7 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -64,13 +64,11 @@ impl TranspileableExpr for NeqExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/logical/and_op.rs
+++ b/rosy/src/program/expressions/operators/logical/and_op.rs
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -55,13 +55,11 @@ impl TranspileableExpr for AndExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/logical/or_op.rs
+++ b/rosy/src/program/expressions/operators/logical/or_op.rs
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -55,13 +55,11 @@ impl TranspileableExpr for OrExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/unary/neg.rs
+++ b/rosy/src/program/expressions/operators/unary/neg.rs
@@ -23,10 +23,7 @@ use std::collections::HashSet;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{
-    ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-    TranspileableExpr, ValueKind,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
 
@@ -62,10 +59,8 @@ impl TranspileableExpr for NegExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.operand, ctx),
-        }
+    ) -> Option<Result<()>> {
+        Some(resolver.discover_expr_function_calls(&self.operand, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/operators/unary/not.rs
+++ b/rosy/src/program/expressions/operators/unary/not.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -53,10 +53,8 @@ impl TranspileableExpr for NotExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.operand, ctx),
-        }
+    ) -> Option<Result<()>> {
+        Some(resolver.discover_expr_function_calls(&self.operand, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/pow.rs
+++ b/rosy/src/program/expressions/pow.rs
@@ -26,7 +26,7 @@ use crate::ast::{FromRule, Rule};
 use crate::program::expressions::Expr;
 use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use rosy_lib::BinaryOp;
-use crate::transpile::{ExprFunctionCallResult, TranspileableExpr};
+use crate::transpile::TranspileableExpr;
 use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, ValueKind};
 use anyhow::{Error, Result, anyhow};
 use rosy_lib::RosyType;
@@ -58,13 +58,11 @@ impl TranspileableExpr for PowExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_expr_function_calls(&self.left, ctx) {
-            return ExprFunctionCallResult::HasFunctionCalls { result: Err(e) };
+            return Some(Err(e));
         }
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.right, ctx),
-        }
+        Some(resolver.discover_expr_function_calls(&self.right, ctx),)
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/string_convert.rs
+++ b/rosy/src/program/expressions/string_convert.rs
@@ -16,9 +16,7 @@
 
 use anyhow::{anyhow, Error, Result};
 use crate::program::expressions::Expr;
-use crate::transpile::{
-    TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind};
 
 /// Shared emit path for `ST(expr)` — used by the intrinsic and by `WRITE`.
 pub fn string_convert_transpile_helper(

--- a/rosy/src/program/expressions/types/boolean.rs
+++ b/rosy/src/program/expressions/types/boolean.rs
@@ -20,10 +20,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::{
     ast::{FromRule, Rule},
-    transpile::{
-        ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, ValueKind,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind},
 };
 use rosy_lib::RosyType;
 
@@ -45,13 +42,6 @@ impl FromRule for bool {
 impl TranspileableExpr for bool {
     fn type_of(&self, _context: &TranspilationInputContext) -> Result<RosyType> {
         Ok(RosyType::LO())
-    }
-    fn discover_expr_function_calls(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::NoFunctionCalls
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/types/cd.rs
+++ b/rosy/src/program/expressions/types/cd.rs
@@ -18,10 +18,7 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::{
     ast::{FromRule, Rule},
     program::expressions::Expr,
-    transpile::{
-        ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, ValueKind,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind},
 };
 use anyhow::{Context, Error};
 use rosy_lib::RosyType;
@@ -63,10 +60,8 @@ impl TranspileableExpr for CDExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.index, ctx),
-        }
+    ) -> Option<anyhow::Result<()>> {
+        Some(resolver.discover_expr_function_calls(&self.index, ctx))
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/types/da.rs
+++ b/rosy/src/program/expressions/types/da.rs
@@ -18,10 +18,7 @@ use crate::resolve::{ExprRecipe, ScopeContext, TypeResolver, TypeSlot};
 use crate::{
     ast::{FromRule, Rule},
     program::expressions::Expr,
-    transpile::{
-        ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, ValueKind,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind},
 };
 use anyhow::{Context, Error};
 use rosy_lib::RosyType;
@@ -63,10 +60,8 @@ impl TranspileableExpr for DAExpr {
         &self,
         resolver: &mut TypeResolver,
         ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::HasFunctionCalls {
-            result: resolver.discover_expr_function_calls(&self.index, ctx),
-        }
+    ) -> Option<anyhow::Result<()>> {
+        Some(resolver.discover_expr_function_calls(&self.index, ctx))
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/types/number.rs
+++ b/rosy/src/program/expressions/types/number.rs
@@ -25,10 +25,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::{
     ast::{FromRule, Rule},
-    transpile::{
-        ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, ValueKind,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind},
 };
 use rosy_lib::RosyType;
 
@@ -55,13 +52,6 @@ impl FromRule for f64 {
 impl TranspileableExpr for f64 {
     fn type_of(&self, _context: &TranspilationInputContext) -> Result<RosyType> {
         Ok(RosyType::RE())
-    }
-    fn discover_expr_function_calls(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::NoFunctionCalls
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/expressions/types/string.rs
+++ b/rosy/src/program/expressions/types/string.rs
@@ -23,10 +23,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::{
     ast::{FromRule, Rule},
-    transpile::{
-        ExprFunctionCallResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, ValueKind,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, ValueKind},
 };
 use rosy_lib::RosyType;
 
@@ -51,13 +48,6 @@ impl FromRule for String {
 impl TranspileableExpr for String {
     fn type_of(&self, _context: &TranspilationInputContext) -> Result<RosyType> {
         Ok(RosyType::ST())
-    }
-    fn discover_expr_function_calls(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult {
-        ExprFunctionCallResult::NoFunctionCalls
     }
     fn build_expr_recipe(
         &self,

--- a/rosy/src/program/statements.rs
+++ b/rosy/src/program/statements.rs
@@ -166,7 +166,6 @@ pub use da::mtree::MtreeStatement;
 use crate::{
     ast::{FromRule, Rule},
     errors::WithLocation,
-    resolve::*,
     transpile::*,
 };
 use anyhow::{Context, Error, Result, bail};
@@ -231,31 +230,7 @@ pub struct Statement {
     pub inner: StmtKind,
     pub source_location: SourceLocation,
 }
-impl TranspileableStatement for Statement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
+impl TranspileableStatement for Statement {}
 impl FromRule for Statement {
     fn from_rule(pair: pest::iterators::Pair<Rule>) -> Result<Option<Statement>> {
         // Capture source location before the pair is consumed

--- a/rosy/src/program/statements/core/argget.rs
+++ b/rosy/src/program/statements/core/argget.rs
@@ -24,8 +24,6 @@ use std::collections::BTreeSet;
 use crate::{
     ast::*,
     program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
-    program::statements::SourceLocation,
-    resolve::*,
     transpile::*,
 };
 
@@ -64,31 +62,6 @@ impl FromRule for ArggetStatement {
     }
 }
 
-impl TranspileableStatement for ArggetStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for ArggetStatement {
     fn transpile(
@@ -146,3 +119,5 @@ impl Transpile for ArggetStatement {
         })
     }
 }
+
+impl TranspileableStatement for ArggetStatement {}

--- a/rosy/src/program/statements/core/assign.rs
+++ b/rosy/src/program/statements/core/assign.rs
@@ -86,34 +86,32 @@ impl TranspileableStatement for AssignStatement {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
+    ) -> Option<Result<()>> {
         // Clear assignments (`:= .`) don't affect type resolution
         let value = match &self.value {
             Some(v) => v,
-            None => return InferenceEdgeResult::HasEdges { result: Ok(()) },
+            None => return Some(Ok(())),
         };
 
         // Discover function call sites within the RHS expression
         if let Err(e) = resolver.discover_expr_function_calls(value, ctx) {
-            return InferenceEdgeResult::HasEdges {
-                result: Err(e.context(
+            return Some(Err(e.context(
                     "...while discovering function call dependencies in assignment statement",
-                )),
-            };
+                )),);
         }
 
         let var_name = &self.identifier.name;
         let var_slot = match ctx.variables.get(var_name) {
             Some(s) => s.clone(),
-            None => return InferenceEdgeResult::HasEdges { result: Ok(()) }, // unknown variable, skip
+            None => return Some(Ok(())), // unknown variable, skip
         };
 
         // Build a recipe for the RHS expression and collect its dependencies
@@ -221,14 +219,12 @@ impl TranspileableStatement for AssignStatement {
                             new_type.base_type,
                             ve_hint,
                         );
-                        return InferenceEdgeResult::HasEdges {
-                            result: Err(RosyError::at(source_location.clone(), msg).into()),
-                        };
+                        return Some(Err(RosyError::at(source_location.clone(), msg).into()),);
                 }
-                return InferenceEdgeResult::HasEdges { result: Ok(()) }; // already has explicit type, no inference needed
+                return Some(Ok(())); // already has explicit type, no inference needed
             }
         } else {
-            return InferenceEdgeResult::HasEdges { result: Ok(()) };
+            return Some(Ok(()));
         }
 
         // Check for conflicting re-assignment: if a previous assignment
@@ -402,9 +398,7 @@ impl TranspileableStatement for AssignStatement {
                             new_type.base_type,
                             ve_hint,
                         );
-                        return InferenceEdgeResult::HasEdges {
-                            result: Err(RosyError::at(source_location.clone(), msg).into()),
-                        };
+                        return Some(Err(RosyError::at(source_location.clone(), msg).into()),);
                 }
             }
 
@@ -414,7 +408,7 @@ impl TranspileableStatement for AssignStatement {
             // cycles when a variable is re-assigned from a value that
             // transitively depends on itself (e.g. X1 := f(X3) after
             // X3 := g(X1)).
-            return InferenceEdgeResult::HasEdges { result: Ok(()) };
+            return Some(Ok(()));
         }
 
         if let Some(node) = resolver.nodes.get_mut(&var_slot) {
@@ -437,14 +431,14 @@ impl TranspileableStatement for AssignStatement {
             node.assigned_at = Some(source_location);
         }
 
-        InferenceEdgeResult::HasEdges { result: Ok(()) }
+        Some(Ok(()))
     }
     fn hydrate_resolved_types(
         &mut self,
         _resolver: &TypeResolver,
         _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
+    ) -> Option<Result<()>> {
+        None
     }
 }
 impl Transpile for AssignStatement {

--- a/rosy/src/program/statements/core/break.rs
+++ b/rosy/src/program/statements/core/break.rs
@@ -15,7 +15,7 @@
 use anyhow::{Error, Result, anyhow, ensure};
 use std::collections::BTreeSet;
 
-use crate::{ast::*, program::statements::SourceLocation, resolve::*, transpile::*};
+use crate::{ast::*, transpile::*};
 
 #[derive(Debug)]
 pub struct BreakStatement;
@@ -29,31 +29,6 @@ impl FromRule for BreakStatement {
         );
 
         Ok(Some(BreakStatement))
-    }
-}
-impl TranspileableStatement for BreakStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for BreakStatement {
@@ -74,3 +49,5 @@ impl Transpile for BreakStatement {
         })
     }
 }
+
+impl TranspileableStatement for BreakStatement {}

--- a/rosy/src/program/statements/core/function.rs
+++ b/rosy/src/program/statements/core/function.rs
@@ -158,7 +158,7 @@ impl TranspileableStatement for FunctionStatement {
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
+    ) -> Option<Result<()>> {
         // Return type slot
         let ret_slot = TypeSlot::FunctionReturn(ctx.scope_path.clone(), self.name.clone());
         resolver.insert_slot(
@@ -217,7 +217,7 @@ impl TranspileableStatement for FunctionStatement {
             .insert(self.name.clone(), inner_ret_var_slot.clone());
 
         if let Err(e) = resolver.discover_slots(&self.body, &mut inner_ctx) {
-            return TypeslotDeclarationResult::VarFuncOrProcedureDecl { result: Err(e) };
+            return Some(Err(e));
         }
 
         // If the return type is NOT explicit, it depends on the inner return var
@@ -235,21 +235,21 @@ impl TranspileableStatement for FunctionStatement {
                 node.depends_on.insert(inner_ret_var_slot);
         }
 
-        TypeslotDeclarationResult::VarFuncOrProcedureDecl { result: Ok(()) }
+        Some(Ok(()))
     }
     fn wire_inference_edges(
         &self,
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
+    ) -> Option<Result<()>> {
+        None
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         // Return type
         if self.return_type.is_none() {
             let slot = TypeSlot::FunctionReturn(current_scope.to_vec(), self.name.clone());
@@ -277,10 +277,10 @@ impl TranspileableStatement for FunctionStatement {
         let mut inner_scope = current_scope.to_vec();
         inner_scope.push(self.name.clone());
         if let Err(e) = resolver.apply_to_ast(&mut self.body, &inner_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
 
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for FunctionStatement {

--- a/rosy/src/program/statements/core/function_call.rs
+++ b/rosy/src/program/statements/core/function_call.rs
@@ -22,7 +22,7 @@ use crate::{
         expressions::{Expr, core::var_expr::function_call_transpile_helper},
         statements::SourceLocation,
     },
-    resolve::*,
+    resolve::{ScopeContext, TypeResolver},
     transpile::*,
 };
 
@@ -64,38 +64,22 @@ impl FromRule for FunctionCallStatement {
         Ok(Some(FunctionCallStatement { name, args }))
     }
 }
-impl TranspileableStatement for FunctionCallStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        resolver: &mut TypeResolver,
-        ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::HasEdges {
-            result: resolver.discover_call_site_deps(&self.name, &self.args, true, ctx),
-        }
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for FunctionCallStatement {
     fn transpile(
         &self,
         context: &mut TranspilationInputContext,
     ) -> Result<TranspilationOutput, Vec<Error>> {
         function_call_transpile_helper(&self.name, &self.args, context)
+    }
+}
+
+impl TranspileableStatement for FunctionCallStatement {
+    fn wire_inference_edges(
+        &self,
+        resolver: &mut TypeResolver,
+        ctx: &mut ScopeContext,
+        _source_location: SourceLocation,
+    ) -> Option<Result<()>> {
+        Some(resolver.discover_call_site_deps(&self.name, &self.args, true, ctx))
     }
 }

--- a/rosy/src/program/statements/core/if.rs
+++ b/rosy/src/program/statements/core/if.rs
@@ -173,49 +173,49 @@ impl TranspileableStatement for IfStatement {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.discover_slots(&self.then_body, &mut ctx.clone()) {
-            return InferenceEdgeResult::HasEdges { result: Err(e) };
+            return Some(Err(e));
         }
         for elseif in &self.elseif_clauses {
             if let Err(e) = resolver.discover_slots(&elseif.body, &mut ctx.clone()) {
-                return InferenceEdgeResult::HasEdges { result: Err(e) };
+                return Some(Err(e));
             }
         }
         if let Some(else_body) = &self.else_body
             && let Err(e) = resolver.discover_slots(else_body, &mut ctx.clone())
         {
-                return InferenceEdgeResult::HasEdges { result: Err(e) };
+                return Some(Err(e));
         }
-        InferenceEdgeResult::HasEdges { result: Ok(()) }
+        Some(Ok(()))
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.apply_to_ast(&mut self.then_body, current_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
         for elseif in &mut self.elseif_clauses {
             if let Err(e) = resolver.apply_to_ast(&mut elseif.body, current_scope) {
-                return TypeHydrationResult::Hydrated { result: Err(e) };
+                return Some(Err(e));
             }
         }
         if let Some(else_body) = &mut self.else_body
             && let Err(e) = resolver.apply_to_ast(else_body, current_scope)
         {
-                return TypeHydrationResult::Hydrated { result: Err(e) };
+                return Some(Err(e));
         }
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for ElseIfClause {
@@ -417,22 +417,22 @@ impl TranspileableStatement for ElseIfClause {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
+    ) -> Option<Result<()>> {
+        None
     }
     fn hydrate_resolved_types(
         &mut self,
         _resolver: &TypeResolver,
         _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
+    ) -> Option<Result<()>> {
+        None
     }
 }

--- a/rosy/src/program/statements/core/imunit.rs
+++ b/rosy/src/program/statements/core/imunit.rs
@@ -17,8 +17,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation, resolve::*, transpile::*,
+    ast::*, program::expressions::core::variable_identifier::VariableIdentifier, transpile::*,
 };
 
 #[derive(Debug)]
@@ -47,31 +46,6 @@ impl FromRule for ImunitStatement {
     }
 }
 
-impl TranspileableStatement for ImunitStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for ImunitStatement {
     fn transpile(
@@ -117,3 +91,5 @@ impl Transpile for ImunitStatement {
         })
     }
 }
+
+impl TranspileableStatement for ImunitStatement {}

--- a/rosy/src/program/statements/core/lfalse.rs
+++ b/rosy/src/program/statements/core/lfalse.rs
@@ -17,8 +17,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation, resolve::*, transpile::*,
+    ast::*, program::expressions::core::variable_identifier::VariableIdentifier, transpile::*,
 };
 
 #[derive(Debug)]
@@ -47,31 +46,6 @@ impl FromRule for LfalseStatement {
     }
 }
 
-impl TranspileableStatement for LfalseStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for LfalseStatement {
     fn transpile(
@@ -113,3 +87,5 @@ impl Transpile for LfalseStatement {
         })
     }
 }
+
+impl TranspileableStatement for LfalseStatement {}

--- a/rosy/src/program/statements/core/loop.rs
+++ b/rosy/src/program/statements/core/loop.rs
@@ -132,15 +132,15 @@ impl TranspileableStatement for LoopStatement {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
+    ) -> Option<Result<()>> {
         let mut inner_ctx = ctx.clone();
         // Loop iterator is always RE
         let iter_slot = TypeSlot::Variable(ctx.scope_path.clone(), self.iterator.clone());
@@ -150,19 +150,17 @@ impl TranspileableStatement for LoopStatement {
             Some(source_location),
         );
         inner_ctx.variables.insert(self.iterator.clone(), iter_slot);
-        InferenceEdgeResult::HasEdges {
-            result: resolver.discover_slots(&self.body, &mut inner_ctx),
-        }
+        Some(resolver.discover_slots(&self.body, &mut inner_ctx),)
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.apply_to_ast(&mut self.body, current_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for LoopStatement {

--- a/rosy/src/program/statements/core/ltrue.rs
+++ b/rosy/src/program/statements/core/ltrue.rs
@@ -17,8 +17,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation, resolve::*, transpile::*,
+    ast::*, program::expressions::core::variable_identifier::VariableIdentifier, transpile::*,
 };
 
 #[derive(Debug)]
@@ -47,31 +46,6 @@ impl FromRule for LtrueStatement {
     }
 }
 
-impl TranspileableStatement for LtrueStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for LtrueStatement {
     fn transpile(
@@ -113,3 +87,5 @@ impl Transpile for LtrueStatement {
         })
     }
 }
+
+impl TranspileableStatement for LtrueStatement {}

--- a/rosy/src/program/statements/core/memall.rs
+++ b/rosy/src/program/statements/core/memall.rs
@@ -20,8 +20,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation, resolve::*, transpile::*,
+    ast::*, program::expressions::core::variable_identifier::VariableIdentifier, transpile::*,
 };
 
 #[derive(Debug)]
@@ -50,31 +49,6 @@ impl FromRule for MemallStatement {
     }
 }
 
-impl TranspileableStatement for MemallStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for MemallStatement {
     fn transpile(
@@ -118,3 +92,5 @@ impl Transpile for MemallStatement {
         })
     }
 }
+
+impl TranspileableStatement for MemallStatement {}

--- a/rosy/src/program/statements/core/memdpv.rs
+++ b/rosy/src/program/statements/core/memdpv.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::Expr, program::statements::SourceLocation, resolve::*,
+    ast::*, program::expressions::Expr,
     transpile::*,
 };
 
@@ -60,31 +60,6 @@ impl FromRule for MemdpvStatement {
             unit_expr,
             var_expr,
         }))
-    }
-}
-impl TranspileableStatement for MemdpvStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for MemdpvStatement {
@@ -124,3 +99,5 @@ impl Transpile for MemdpvStatement {
         })
     }
 }
+
+impl TranspileableStatement for MemdpvStatement {}

--- a/rosy/src/program/statements/core/memfre.rs
+++ b/rosy/src/program/statements/core/memfre.rs
@@ -19,8 +19,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation, resolve::*, transpile::*,
+    ast::*, program::expressions::core::variable_identifier::VariableIdentifier, transpile::*,
 };
 
 #[derive(Debug)]
@@ -49,31 +48,6 @@ impl FromRule for MemfreStatement {
     }
 }
 
-impl TranspileableStatement for MemfreStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for MemfreStatement {
     fn transpile(
@@ -117,3 +91,5 @@ impl Transpile for MemfreStatement {
         })
     }
 }
+
+impl TranspileableStatement for MemfreStatement {}

--- a/rosy/src/program/statements/core/memwrt.rs
+++ b/rosy/src/program/statements/core/memwrt.rs
@@ -20,12 +20,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `MEMWRT c;`.
@@ -53,31 +49,6 @@ impl FromRule for MemwrtStatement {
     }
 }
 
-impl TranspileableStatement for MemwrtStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for MemwrtStatement {
     fn transpile(
@@ -104,3 +75,5 @@ impl Transpile for MemwrtStatement {
         })
     }
 }
+
+impl TranspileableStatement for MemwrtStatement {}

--- a/rosy/src/program/statements/core/ploop.rs
+++ b/rosy/src/program/statements/core/ploop.rs
@@ -179,15 +179,15 @@ impl TranspileableStatement for PLoopStatement {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
+    ) -> Option<Result<()>> {
         let mut inner_ctx = ctx.clone();
         let iter_slot = TypeSlot::Variable(ctx.scope_path.clone(), self.iterator.clone());
         resolver.insert_slot(
@@ -195,19 +195,17 @@ impl TranspileableStatement for PLoopStatement {
             Some(&RosyType::RE()),
             Some(source_location),
         );
-        InferenceEdgeResult::HasEdges {
-            result: resolver.discover_slots(&self.body, &mut inner_ctx),
-        }
+        Some(resolver.discover_slots(&self.body, &mut inner_ctx),)
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.apply_to_ast(&mut self.body, current_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for PLoopStatement {

--- a/rosy/src/program/statements/core/pnpro.rs
+++ b/rosy/src/program/statements/core/pnpro.rs
@@ -17,8 +17,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation, resolve::*, transpile::*,
+    ast::*, program::expressions::core::variable_identifier::VariableIdentifier, transpile::*,
 };
 
 #[derive(Debug)]
@@ -47,31 +46,6 @@ impl FromRule for PnproStatement {
     }
 }
 
-impl TranspileableStatement for PnproStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for PnproStatement {
     fn transpile(
@@ -119,3 +93,5 @@ impl Transpile for PnproStatement {
         })
     }
 }
+
+impl TranspileableStatement for PnproStatement {}

--- a/rosy/src/program/statements/core/procedure.rs
+++ b/rosy/src/program/statements/core/procedure.rs
@@ -124,7 +124,7 @@ impl TranspileableStatement for ProcedureStatement {
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
+    ) -> Option<Result<()>> {
         let mut arg_slots = Vec::new();
         for arg in &self.args {
             let arg_slot =
@@ -157,24 +157,24 @@ impl TranspileableStatement for ProcedureStatement {
         }
 
         if let Err(e) = resolver.discover_slots(&self.body, &mut inner_ctx) {
-            return TypeslotDeclarationResult::VarFuncOrProcedureDecl { result: Err(e) };
+            return Some(Err(e));
         }
 
-        TypeslotDeclarationResult::VarFuncOrProcedureDecl { result: Ok(()) }
+        Some(Ok(()))
     }
     fn wire_inference_edges(
         &self,
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
+    ) -> Option<Result<()>> {
+        None
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         for arg in &mut self.args {
             if arg.r#type.is_none() {
                 let slot =
@@ -190,10 +190,10 @@ impl TranspileableStatement for ProcedureStatement {
         let mut inner_scope = current_scope.to_vec();
         inner_scope.push(self.name.clone());
         if let Err(e) = resolver.apply_to_ast(&mut self.body, &inner_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
 
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for ProcedureStatement {

--- a/rosy/src/program/statements/core/procedure_call.rs
+++ b/rosy/src/program/statements/core/procedure_call.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeSet;
 use crate::{
     ast::*,
     program::{expressions::Expr, statements::SourceLocation},
-    resolve::*,
+    resolve::{ScopeContext, TypeResolver},
     transpile::*,
 };
 
@@ -64,33 +64,6 @@ impl FromRule for ProcedureCallStatement {
         }
 
         Ok(Some(ProcedureCallStatement { name, args }))
-    }
-}
-impl TranspileableStatement for ProcedureCallStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        resolver: &mut TypeResolver,
-        ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::HasEdges {
-            result: resolver.discover_call_site_deps(&self.name, &self.args, false, ctx),
-        }
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for ProcedureCallStatement {
@@ -283,5 +256,16 @@ impl Transpile for ProcedureCallStatement {
         } else {
             Err(errors)
         }
+    }
+}
+
+impl TranspileableStatement for ProcedureCallStatement {
+    fn wire_inference_edges(
+        &self,
+        resolver: &mut TypeResolver,
+        ctx: &mut ScopeContext,
+        _source_location: SourceLocation,
+    ) -> Option<Result<()>> {
+        Some(resolver.discover_call_site_deps(&self.name, &self.args, false, ctx))
     }
 }

--- a/rosy/src/program/statements/core/quit.rs
+++ b/rosy/src/program/statements/core/quit.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::Expr, program::statements::SourceLocation, resolve::*,
+    ast::*, program::expressions::Expr,
     transpile::*,
 };
 
@@ -49,31 +49,6 @@ impl FromRule for QuitStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected code expression in QUIT"))?;
 
         Ok(Some(QuitStatement { code_expr }))
-    }
-}
-impl TranspileableStatement for QuitStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for QuitStatement {
@@ -110,3 +85,5 @@ impl Transpile for QuitStatement {
         })
     }
 }
+
+impl TranspileableStatement for QuitStatement {}

--- a/rosy/src/program/statements/core/ranseed.rs
+++ b/rosy/src/program/statements/core/ranseed.rs
@@ -22,12 +22,8 @@ use anyhow::{Context, Error, Result, ensure};
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement},
 };
 
 /// AST node for the `RANSEED seed;` statement.
@@ -57,31 +53,6 @@ impl FromRule for RanseedStatement {
     }
 }
 
-impl TranspileableStatement for RanseedStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for RanseedStatement {
     fn transpile(
@@ -106,3 +77,5 @@ impl Transpile for RanseedStatement {
         })
     }
 }
+
+impl TranspileableStatement for RanseedStatement {}

--- a/rosy/src/program/statements/core/recst.rs
+++ b/rosy/src/program/statements/core/recst.rs
@@ -23,8 +23,6 @@ use std::collections::BTreeSet;
 use crate::{
     ast::*,
     program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
-    program::statements::SourceLocation,
-    resolve::*,
     transpile::*,
 };
 
@@ -70,31 +68,6 @@ impl FromRule for RecstStatement {
     }
 }
 
-impl TranspileableStatement for RecstStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for RecstStatement {
     fn transpile(
@@ -157,3 +130,5 @@ impl Transpile for RecstStatement {
         })
     }
 }
+
+impl TranspileableStatement for RecstStatement {}

--- a/rosy/src/program/statements/core/reran.rs
+++ b/rosy/src/program/statements/core/reran.rs
@@ -21,11 +21,8 @@ use std::collections::BTreeSet;
 use crate::{
     ast::*,
     program::expressions::core::variable_identifier::VariableIdentifier,
-    program::statements::SourceLocation,
-    resolve::{ExprRecipe, ResolutionRule, ScopeContext, TypeResolver},
     transpile::*,
 };
-use rosy_lib::RosyType;
 
 #[derive(Debug)]
 pub struct ReranStatement {
@@ -51,45 +48,6 @@ impl FromRule for ReranStatement {
     }
 }
 
-impl TranspileableStatement for ReranStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        resolver: &mut TypeResolver,
-        ctx: &mut ScopeContext,
-        source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        // RERAN always assigns an RE (f64) value to the target variable
-        let slot = match ctx.variables.get(&self.output_var.name) {
-            Some(s) => s,
-            None => return InferenceEdgeResult::NoEdges,
-        };
-        if let Some(node) = resolver.nodes.get_mut(slot)
-            && node.resolved.is_none()
-        {
-                node.rule = ResolutionRule::InferredFrom {
-                    recipe: ExprRecipe::Literal(RosyType::RE()),
-                    reason: format!("inferred from RERAN at {}", source_location),
-                };
-                node.assigned_at = Some(source_location);
-        }
-        InferenceEdgeResult::HasEdges { result: Ok(()) }
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for ReranStatement {
     fn transpile(
@@ -127,7 +85,7 @@ impl Transpile for ReranStatement {
 
         // Generate random f64 in [-1, 1] using thread_rng
         let serialization = format!(
-            "{deref}{dest} = rosy_lib::core::reran::rosy_reran();",
+            "{deref}{dest} = rosy_lib::core::rng::rosy_reran();",
             deref = dereference,
             dest = output_id_output.serialization,
         );
@@ -139,3 +97,5 @@ impl Transpile for ReranStatement {
         })
     }
 }
+
+impl TranspileableStatement for ReranStatement {}

--- a/rosy/src/program/statements/core/scrlen.rs
+++ b/rosy/src/program/statements/core/scrlen.rs
@@ -22,7 +22,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::Expr, program::statements::SourceLocation, resolve::*,
+    ast::*, program::expressions::Expr,
     transpile::*,
 };
 
@@ -48,31 +48,6 @@ impl FromRule for ScrlenStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected size expression in SCRLEN"))?;
 
         Ok(Some(ScrlenStatement { size_expr }))
-    }
-}
-impl TranspileableStatement for ScrlenStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for ScrlenStatement {
@@ -103,3 +78,5 @@ impl Transpile for ScrlenStatement {
         })
     }
 }
+
+impl TranspileableStatement for ScrlenStatement {}

--- a/rosy/src/program/statements/core/sleepm.rs
+++ b/rosy/src/program/statements/core/sleepm.rs
@@ -21,7 +21,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::Expr, program::statements::SourceLocation, resolve::*,
+    ast::*, program::expressions::Expr,
     transpile::*,
 };
 
@@ -51,31 +51,6 @@ impl FromRule for SleepmStatement {
         Ok(Some(SleepmStatement { duration_expr }))
     }
 }
-impl TranspileableStatement for SleepmStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for SleepmStatement {
     fn transpile(
         &self,
@@ -103,3 +78,5 @@ impl Transpile for SleepmStatement {
         })
     }
 }
+
+impl TranspileableStatement for SleepmStatement {}

--- a/rosy/src/program/statements/core/stcre.rs
+++ b/rosy/src/program/statements/core/stcre.rs
@@ -22,8 +22,6 @@ use std::collections::BTreeSet;
 use crate::{
     ast::*,
     program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
-    program::statements::SourceLocation,
-    resolve::*,
     transpile::*,
 };
 
@@ -62,31 +60,6 @@ impl FromRule for StcreStatement {
     }
 }
 
-impl TranspileableStatement for StcreStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for StcreStatement {
     fn transpile(
@@ -144,3 +117,5 @@ impl Transpile for StcreStatement {
         })
     }
 }
+
+impl TranspileableStatement for StcreStatement {}

--- a/rosy/src/program/statements/core/substr.rs
+++ b/rosy/src/program/statements/core/substr.rs
@@ -24,8 +24,6 @@ use std::collections::BTreeSet;
 use crate::{
     ast::*,
     program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
-    program::statements::SourceLocation,
-    resolve::*,
     transpile::*,
 };
 
@@ -85,31 +83,6 @@ impl FromRule for SubstrStatement {
     }
 }
 
-impl TranspileableStatement for SubstrStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for SubstrStatement {
     fn transpile(
@@ -193,3 +166,5 @@ impl Transpile for SubstrStatement {
         })
     }
 }
+
+impl TranspileableStatement for SubstrStatement {}

--- a/rosy/src/program/statements/core/var_decl.rs
+++ b/rosy/src/program/statements/core/var_decl.rs
@@ -241,7 +241,7 @@ impl TranspileableStatement for VarDeclStatement {
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
+    ) -> Option<Result<()>> {
         let slot = TypeSlot::Variable(ctx.scope_path.clone(), self.data.name.clone());
 
         resolver.insert_slot(
@@ -251,21 +251,21 @@ impl TranspileableStatement for VarDeclStatement {
         );
         ctx.variables.insert(self.data.name.clone(), slot);
 
-        TypeslotDeclarationResult::VarFuncOrProcedureDecl { result: Ok(()) }
+        Some(Ok(()))
     }
     fn wire_inference_edges(
         &self,
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
+    ) -> Option<Result<()>> {
+        None
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         if self.data.r#type.is_none() {
             let slot = TypeSlot::Variable(current_scope.to_vec(), self.data.name.clone());
             if let Some(node) = resolver.nodes.get(&slot)
@@ -278,7 +278,7 @@ impl TranspileableStatement for VarDeclStatement {
                     self.data.r#type = Some(resolved);
             }
         }
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for VarDeclStatement {

--- a/rosy/src/program/statements/core/velset.rs
+++ b/rosy/src/program/statements/core/velset.rs
@@ -75,44 +75,6 @@ impl FromRule for VelsetStatement {
     }
 }
 
-impl TranspileableStatement for VelsetStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        resolver: &mut TypeResolver,
-        ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        // Discover function call sites within the component and value expressions
-        if let Err(e) = resolver.discover_expr_function_calls(&self.component_expr, ctx) {
-            return InferenceEdgeResult::HasEdges { result: Err(e.context(
-                "...while discovering function call dependencies in VELSET component expression",
-            )) };
-        }
-        if let Err(e) = resolver.discover_expr_function_calls(&self.value_expr, ctx) {
-            return InferenceEdgeResult::HasEdges {
-                result: Err(e.context(
-                    "...while discovering function call dependencies in VELSET value expression",
-                )),
-            };
-        }
-        InferenceEdgeResult::HasEdges { result: Ok(()) }
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for VelsetStatement {
     fn transpile(
@@ -173,5 +135,26 @@ impl Transpile for VelsetStatement {
             requested_variables,
             ..Default::default()
         })
+    }
+}
+
+impl TranspileableStatement for VelsetStatement {
+    fn wire_inference_edges(
+        &self,
+        resolver: &mut TypeResolver,
+        ctx: &mut ScopeContext,
+        _source_location: SourceLocation,
+    ) -> Option<Result<()>> {
+        if let Err(e) = resolver.discover_expr_function_calls(&self.component_expr, ctx) {
+            return Some(Err(e.context(
+                "...while discovering function call dependencies in VELSET component expression",
+            )));
+        }
+        if let Err(e) = resolver.discover_expr_function_calls(&self.value_expr, ctx) {
+            return Some(Err(e.context(
+                "...while discovering function call dependencies in VELSET value expression",
+            )));
+        }
+        Some(Ok(()))
     }
 }

--- a/rosy/src/program/statements/core/while_loop.rs
+++ b/rosy/src/program/statements/core/while_loop.rs
@@ -86,28 +86,26 @@ impl TranspileableStatement for WhileStatement {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::HasEdges {
-            result: resolver.discover_slots(&self.body, &mut ctx.clone()),
-        }
+    ) -> Option<Result<()>> {
+        Some(resolver.discover_slots(&self.body, &mut ctx.clone()),)
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.apply_to_ast(&mut self.body, current_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for WhileStatement {

--- a/rosy/src/program/statements/da/cdf2.rs
+++ b/rosy/src/program/statements/da/cdf2.rs
@@ -21,12 +21,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `CDF2 input tune1 tune2 tune3 result;` statement.
@@ -79,31 +75,6 @@ impl FromRule for Cdf2Statement {
     }
 }
 
-impl TranspileableStatement for Cdf2Statement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for Cdf2Statement {
     fn transpile(
@@ -159,3 +130,5 @@ impl Transpile for Cdf2Statement {
         })
     }
 }
+
+impl TranspileableStatement for Cdf2Statement {}

--- a/rosy/src/program/statements/da/cdflo.rs
+++ b/rosy/src/program/statements/da/cdflo.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `CDFLO rhs ic result dim;` complex ODE flow statement.
@@ -71,31 +67,6 @@ impl FromRule for CdfloStatement {
     }
 }
 
-impl TranspileableStatement for CdfloStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for CdfloStatement {
     fn transpile(
@@ -143,3 +114,5 @@ impl Transpile for CdfloStatement {
         })
     }
 }
+
+impl TranspileableStatement for CdfloStatement {}

--- a/rosy/src/program/statements/da/cdnf.rs
+++ b/rosy/src/program/statements/da/cdnf.rs
@@ -20,12 +20,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `CDNF input t1 t2 t3 resonances res_dims n_res result;`.
@@ -96,31 +92,6 @@ impl FromRule for CdnfStatement {
     }
 }
 
-impl TranspileableStatement for CdnfStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for CdnfStatement {
     fn transpile(
@@ -195,3 +166,5 @@ impl Transpile for CdnfStatement {
         })
     }
 }
+
+impl TranspileableStatement for CdnfStatement {}

--- a/rosy/src/program/statements/da/cdnfda.rs
+++ b/rosy/src/program/statements/da/cdnfda.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `CDNFDA input moduli arguments coord total epsilon result;`.
@@ -80,31 +76,6 @@ impl FromRule for CdnfdaStatement {
     }
 }
 
-impl TranspileableStatement for CdnfdaStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for CdnfdaStatement {
     fn transpile(
@@ -168,3 +139,5 @@ impl Transpile for CdnfdaStatement {
         })
     }
 }
+
+impl TranspileableStatement for CdnfdaStatement {}

--- a/rosy/src/program/statements/da/cdnfds.rs
+++ b/rosy/src/program/statements/da/cdnfds.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `CDNFDS input moduli arguments spin_arg total epsilon result;`.
@@ -80,31 +76,6 @@ impl FromRule for CdnfdsStatement {
     }
 }
 
-impl TranspileableStatement for CdnfdsStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for CdnfdsStatement {
     fn transpile(
@@ -168,3 +139,5 @@ impl Transpile for CdnfdsStatement {
         })
     }
 }
+
+impl TranspileableStatement for CdnfdsStatement {}

--- a/rosy/src/program/statements/da/da_init.rs
+++ b/rosy/src/program/statements/da/da_init.rs
@@ -20,13 +20,9 @@ use anyhow::{Context, Error, Result, ensure};
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
+    program::expressions::Expr,
     syntax_config,
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement},
 };
 
 /// AST node for the `DAINI order nvars [output_unit num_monomials_out];` statement.
@@ -119,31 +115,6 @@ impl FromRule for DAInitStatement {
         }))
     }
 }
-impl TranspileableStatement for DAInitStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for DAInitStatement {
     fn transpile(
         &self,
@@ -210,3 +181,5 @@ impl Transpile for DAInitStatement {
         })
     }
 }
+
+impl TranspileableStatement for DAInitStatement {}

--- a/rosy/src/program/statements/da/dacliw.rs
+++ b/rosy/src/program/statements/da/dacliw.rs
@@ -24,12 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DACLIW da n linear;`.
@@ -75,31 +71,6 @@ impl FromRule for DacliwStatement {
     }
 }
 
-impl TranspileableStatement for DacliwStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DacliwStatement {
     fn transpile(
@@ -139,3 +110,5 @@ impl Transpile for DacliwStatement {
         })
     }
 }
+
+impl TranspileableStatement for DacliwStatement {}

--- a/rosy/src/program/statements/da/dacode.rs
+++ b/rosy/src/program/statements/da/dacode.rs
@@ -22,12 +22,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DACODE params size result;` monomial decode statement.
@@ -68,31 +64,6 @@ impl FromRule for DacodeStatement {
     }
 }
 
-impl TranspileableStatement for DacodeStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DacodeStatement {
     fn transpile(
@@ -131,3 +102,5 @@ impl Transpile for DacodeStatement {
         })
     }
 }
+
+impl TranspileableStatement for DacodeStatement {}

--- a/rosy/src/program/statements/da/dacqlc.rs
+++ b/rosy/src/program/statements/da/dacqlc.rs
@@ -26,12 +26,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DACQLC da n hessian linear constant;`.
@@ -95,31 +91,6 @@ impl FromRule for DacqlcStatement {
     }
 }
 
-impl TranspileableStatement for DacqlcStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DacqlcStatement {
     fn transpile(
@@ -171,3 +142,5 @@ impl Transpile for DacqlcStatement {
         })
     }
 }
+
+impl TranspileableStatement for DacqlcStatement {}

--- a/rosy/src/program/statements/da/dader.rs
+++ b/rosy/src/program/statements/da/dader.rs
@@ -25,12 +25,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DADER da_var var_index;`.
@@ -69,31 +65,6 @@ impl FromRule for DaderStatement {
     }
 }
 
-impl TranspileableStatement for DaderStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DaderStatement {
     fn transpile(
@@ -127,3 +98,5 @@ impl Transpile for DaderStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaderStatement {}

--- a/rosy/src/program/statements/da/dadiu.rs
+++ b/rosy/src/program/statements/da/dadiu.rs
@@ -24,12 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DADIU i da_in result;`.
@@ -73,31 +69,6 @@ impl FromRule for DadiuStatement {
     }
 }
 
-impl TranspileableStatement for DadiuStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DadiuStatement {
     fn transpile(
@@ -135,3 +106,5 @@ impl Transpile for DadiuStatement {
         })
     }
 }
+
+impl TranspileableStatement for DadiuStatement {}

--- a/rosy/src/program/statements/da/dadmu.rs
+++ b/rosy/src/program/statements/da/dadmu.rs
@@ -25,12 +25,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DADMU i j da_in result;`.
@@ -81,31 +77,6 @@ impl FromRule for DadmuStatement {
     }
 }
 
-impl TranspileableStatement for DadmuStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DadmuStatement {
     fn transpile(
@@ -149,3 +120,5 @@ impl Transpile for DadmuStatement {
         })
     }
 }
+
+impl TranspileableStatement for DadmuStatement {}

--- a/rosy/src/program/statements/da/daeps.rs
+++ b/rosy/src/program/statements/da/daeps.rs
@@ -18,12 +18,8 @@ use anyhow::{Context, Error, Result, ensure};
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement},
 };
 
 /// AST node for the `DAEPS c;` DA epsilon statement.
@@ -54,31 +50,6 @@ impl FromRule for DaepsStatement {
         }))
     }
 }
-impl TranspileableStatement for DaepsStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for DaepsStatement {
     fn transpile(
         &self,
@@ -102,3 +73,5 @@ impl Transpile for DaepsStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaepsStatement {}

--- a/rosy/src/program/statements/da/daepsm.rs
+++ b/rosy/src/program/statements/da/daepsm.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DAEPSM v;` DA epsilon getter statement.
@@ -54,31 +50,6 @@ impl FromRule for DaepsmStatement {
     }
 }
 
-impl TranspileableStatement for DaepsmStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DaepsmStatement {
     fn transpile(
@@ -103,3 +74,5 @@ impl Transpile for DaepsmStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaepsmStatement {}

--- a/rosy/src/program/statements/da/daest.rs
+++ b/rosy/src/program/statements/da/daest.rs
@@ -20,12 +20,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAEST da_var i j result;`.
@@ -76,31 +72,6 @@ impl FromRule for DaestStatement {
     }
 }
 
-impl TranspileableStatement for DaestStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DaestStatement {
     fn transpile(
@@ -146,3 +117,5 @@ impl Transpile for DaestStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaestStatement {}

--- a/rosy/src/program/statements/da/dafilt.rs
+++ b/rosy/src/program/statements/da/dafilt.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DAFILT input result;` filter statement.
@@ -62,31 +58,6 @@ impl FromRule for DafiltStatement {
     }
 }
 
-impl TranspileableStatement for DafiltStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DafiltStatement {
     fn transpile(
@@ -119,3 +90,5 @@ impl Transpile for DafiltStatement {
         })
     }
 }
+
+impl TranspileableStatement for DafiltStatement {}

--- a/rosy/src/program/statements/da/daflo.rs
+++ b/rosy/src/program/statements/da/daflo.rs
@@ -22,12 +22,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DAFLO rhs ic result dim;` ODE flow statement.
@@ -74,31 +70,6 @@ impl FromRule for DafloStatement {
     }
 }
 
-impl TranspileableStatement for DafloStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DafloStatement {
     fn transpile(
@@ -146,3 +117,5 @@ impl Transpile for DafloStatement {
         })
     }
 }
+
+impl TranspileableStatement for DafloStatement {}

--- a/rosy/src/program/statements/da/dafset.rs
+++ b/rosy/src/program/statements/da/dafset.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DAFSET template_da;` filter set statement.
@@ -54,31 +50,6 @@ impl FromRule for DafsetStatement {
     }
 }
 
-impl TranspileableStatement for DafsetStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DafsetStatement {
     fn transpile(
@@ -104,3 +75,5 @@ impl Transpile for DafsetStatement {
         })
     }
 }
+
+impl TranspileableStatement for DafsetStatement {}

--- a/rosy/src/program/statements/da/dagmd.rs
+++ b/rosy/src/program/statements/da/dagmd.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DAGMD g f result dim;` Lie derivative statement.
@@ -78,31 +74,6 @@ impl FromRule for DagmdStatement {
     }
 }
 
-impl TranspileableStatement for DagmdStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DagmdStatement {
     fn transpile(
@@ -150,3 +121,5 @@ impl Transpile for DagmdStatement {
         })
     }
 }
+
+impl TranspileableStatement for DagmdStatement {}

--- a/rosy/src/program/statements/da/daint.rs
+++ b/rosy/src/program/statements/da/daint.rs
@@ -26,12 +26,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAINT da_var var_index;`.
@@ -70,31 +66,6 @@ impl FromRule for DaintStatement {
     }
 }
 
-impl TranspileableStatement for DaintStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DaintStatement {
     fn transpile(
@@ -128,3 +99,5 @@ impl Transpile for DaintStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaintStatement {}

--- a/rosy/src/program/statements/da/danoro.rs
+++ b/rosy/src/program/statements/da/danoro.rs
@@ -25,12 +25,8 @@ use anyhow::{Context, Error, Result, ensure};
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DANORO da_var;`.
@@ -60,31 +56,6 @@ impl FromRule for DanoroStatement {
     }
 }
 
-impl TranspileableStatement for DanoroStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DanoroStatement {
     fn transpile(
@@ -106,3 +77,5 @@ impl Transpile for DanoroStatement {
         })
     }
 }
+
+impl TranspileableStatement for DanoroStatement {}

--- a/rosy/src/program/statements/da/danors.rs
+++ b/rosy/src/program/statements/da/danors.rs
@@ -26,12 +26,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DANORS da_var threshold;`.
@@ -72,31 +68,6 @@ impl FromRule for DanorsStatement {
     }
 }
 
-impl TranspileableStatement for DanorsStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DanorsStatement {
     fn transpile(
@@ -130,3 +101,5 @@ impl Transpile for DanorsStatement {
         })
     }
 }
+
+impl TranspileableStatement for DanorsStatement {}

--- a/rosy/src/program/statements/da/danot.rs
+++ b/rosy/src/program/statements/da/danot.rs
@@ -17,12 +17,8 @@ use anyhow::{Context, Error, Result, ensure};
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement},
 };
 
 /// AST node for the `DANOT c;` DA truncation order statement.
@@ -51,31 +47,6 @@ impl FromRule for DanotStatement {
         Ok(Some(DanotStatement { order: order_expr }))
     }
 }
-impl TranspileableStatement for DanotStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for DanotStatement {
     fn transpile(
         &self,
@@ -99,3 +70,5 @@ impl Transpile for DanotStatement {
         })
     }
 }
+
+impl TranspileableStatement for DanotStatement {}

--- a/rosy/src/program/statements/da/danotw.rs
+++ b/rosy/src/program/statements/da/danotw.rs
@@ -20,12 +20,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DANOTW weights size;` weighted order statement.
@@ -63,31 +59,6 @@ impl FromRule for DanotwStatement {
     }
 }
 
-impl TranspileableStatement for DanotwStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DanotwStatement {
     fn transpile(
@@ -119,3 +90,5 @@ impl Transpile for DanotwStatement {
         })
     }
 }
+
+impl TranspileableStatement for DanotwStatement {}

--- a/rosy/src/program/statements/da/danow.rs
+++ b/rosy/src/program/statements/da/danow.rs
@@ -20,12 +20,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DANOW da_var weight result;` order-weighted norm statement.
@@ -66,31 +62,6 @@ impl FromRule for DanowStatement {
     }
 }
 
-impl TranspileableStatement for DanowStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DanowStatement {
     fn transpile(
@@ -132,3 +103,5 @@ impl Transpile for DanowStatement {
         })
     }
 }
+
+impl TranspileableStatement for DanowStatement {}

--- a/rosy/src/program/statements/da/dapea.rs
+++ b/rosy/src/program/statements/da/dapea.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAPEA da_var exps_array size result;`.
@@ -77,31 +73,6 @@ impl FromRule for DapeaStatement {
     }
 }
 
-impl TranspileableStatement for DapeaStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DapeaStatement {
     fn transpile(
@@ -146,3 +117,5 @@ impl Transpile for DapeaStatement {
         })
     }
 }
+
+impl TranspileableStatement for DapeaStatement {}

--- a/rosy/src/program/statements/da/dapee.rs
+++ b/rosy/src/program/statements/da/dapee.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAPEE da_var id result;`.
@@ -68,31 +64,6 @@ impl FromRule for DapeeStatement {
     }
 }
 
-impl TranspileableStatement for DapeeStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DapeeStatement {
     fn transpile(
@@ -131,3 +102,5 @@ impl Transpile for DapeeStatement {
         })
     }
 }
+
+impl TranspileableStatement for DapeeStatement {}

--- a/rosy/src/program/statements/da/dapep.rs
+++ b/rosy/src/program/statements/da/dapep.rs
@@ -20,12 +20,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAPEP da_var id m result;`.
@@ -76,31 +72,6 @@ impl FromRule for DapepStatement {
     }
 }
 
-impl TranspileableStatement for DapepStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DapepStatement {
     fn transpile(
@@ -146,3 +117,5 @@ impl Transpile for DapepStatement {
         })
     }
 }
+
+impl TranspileableStatement for DapepStatement {}

--- a/rosy/src/program/statements/da/dapew.rs
+++ b/rosy/src/program/statements/da/dapew.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAPEW unit da_var var_i order_n;`.
@@ -77,31 +73,6 @@ impl FromRule for DapewStatement {
     }
 }
 
-impl TranspileableStatement for DapewStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DapewStatement {
     fn transpile(
@@ -146,3 +117,5 @@ impl Transpile for DapewStatement {
         })
     }
 }
+
+impl TranspileableStatement for DapewStatement {}

--- a/rosy/src/program/statements/da/daplu.rs
+++ b/rosy/src/program/statements/da/daplu.rs
@@ -24,12 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAPLU da_in i C result;`.
@@ -80,31 +76,6 @@ impl FromRule for DapluStatement {
     }
 }
 
-impl TranspileableStatement for DapluStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DapluStatement {
     fn transpile(
@@ -161,3 +132,5 @@ impl Transpile for DapluStatement {
         })
     }
 }
+
+impl TranspileableStatement for DapluStatement {}

--- a/rosy/src/program/statements/da/daprv.rs
+++ b/rosy/src/program/statements/da/daprv.rs
@@ -18,12 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAPRV array num_components max_vars current_vars unit;`.
@@ -87,31 +83,6 @@ impl FromRule for DaprvStatement {
         }))
     }
 }
-impl TranspileableStatement for DaprvStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for DaprvStatement {
     fn transpile(
         &self,
@@ -164,3 +135,5 @@ impl Transpile for DaprvStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaprvStatement {}

--- a/rosy/src/program/statements/da/daran.rs
+++ b/rosy/src/program/statements/da/daran.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `DARAN da_var sparsity;` random DA fill statement.
@@ -60,31 +56,6 @@ impl FromRule for DaranStatement {
     }
 }
 
-impl TranspileableStatement for DaranStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DaranStatement {
     fn transpile(
@@ -117,3 +88,5 @@ impl Transpile for DaranStatement {
         })
     }
 }
+
+impl TranspileableStatement for DaranStatement {}

--- a/rosy/src/program/statements/da/darea.rs
+++ b/rosy/src/program/statements/da/darea.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAREA unit da_var num_vars;`.
@@ -70,31 +66,6 @@ impl FromRule for DareaStatement {
     }
 }
 
-impl TranspileableStatement for DareaStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DareaStatement {
     fn transpile(
@@ -133,3 +104,5 @@ impl Transpile for DareaStatement {
         })
     }
 }
+
+impl TranspileableStatement for DareaStatement {}

--- a/rosy/src/program/statements/da/darev.rs
+++ b/rosy/src/program/statements/da/darev.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DAREV array num_components max_vars current_vars unit;`.
@@ -88,31 +84,6 @@ impl FromRule for DarevStatement {
         }))
     }
 }
-impl TranspileableStatement for DarevStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for DarevStatement {
     fn transpile(
         &self,
@@ -165,3 +136,5 @@ impl Transpile for DarevStatement {
         })
     }
 }
+
+impl TranspileableStatement for DarevStatement {}

--- a/rosy/src/program/statements/da/dascl.rs
+++ b/rosy/src/program/statements/da/dascl.rs
@@ -26,12 +26,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DASCL da_var scalar;`.
@@ -68,31 +64,6 @@ impl FromRule for DasclStatement {
     }
 }
 
-impl TranspileableStatement for DasclStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DasclStatement {
     fn transpile(
@@ -126,3 +97,5 @@ impl Transpile for DasclStatement {
         })
     }
 }
+
+impl TranspileableStatement for DasclStatement {}

--- a/rosy/src/program/statements/da/dasgn.rs
+++ b/rosy/src/program/statements/da/dasgn.rs
@@ -24,12 +24,8 @@ use anyhow::{Context, Error, Result, ensure};
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DASGN da_var;`.
@@ -57,31 +53,6 @@ impl FromRule for DasgnStatement {
     }
 }
 
-impl TranspileableStatement for DasgnStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DasgnStatement {
     fn transpile(
@@ -103,3 +74,5 @@ impl Transpile for DasgnStatement {
         })
     }
 }
+
+impl TranspileableStatement for DasgnStatement {}

--- a/rosy/src/program/statements/da/datrn.rs
+++ b/rosy/src/program/statements/da/datrn.rs
@@ -27,12 +27,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `DATRN input scales shifts m1 m2 output;`.
@@ -97,31 +93,6 @@ impl FromRule for DatrnStatement {
     }
 }
 
-impl TranspileableStatement for DatrnStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for DatrnStatement {
     fn transpile(
@@ -179,3 +150,5 @@ impl Transpile for DatrnStatement {
         })
     }
 }
+
+impl TranspileableStatement for DatrnStatement {}

--- a/rosy/src/program/statements/da/epsmin.rs
+++ b/rosy/src/program/statements/da/epsmin.rs
@@ -19,12 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `EPSMIN v;` machine underflow threshold statement.
@@ -54,31 +50,6 @@ impl FromRule for EpsminStatement {
     }
 }
 
-impl TranspileableStatement for EpsminStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for EpsminStatement {
     fn transpile(
@@ -103,3 +74,5 @@ impl Transpile for EpsminStatement {
         })
     }
 }
+
+impl TranspileableStatement for EpsminStatement {}

--- a/rosy/src/program/statements/da/mtree.rs
+++ b/rosy/src/program/statements/da/mtree.rs
@@ -26,13 +26,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -113,31 +108,6 @@ impl FromRule for MtreeStatement {
     }
 }
 
-impl TranspileableStatement for MtreeStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for MtreeStatement {
     fn transpile(
@@ -230,3 +200,5 @@ impl Transpile for MtreeStatement {
         })
     }
 }
+
+impl TranspileableStatement for MtreeStatement {}

--- a/rosy/src/program/statements/io/backf.rs
+++ b/rosy/src/program/statements/io/backf.rs
@@ -18,12 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `BACKF unit;`.
@@ -48,31 +44,6 @@ impl FromRule for BackfStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected unit expression in BACKF"))?;
 
         Ok(Some(BackfStatement { unit_expr }))
-    }
-}
-impl TranspileableStatement for BackfStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for BackfStatement {
@@ -102,3 +73,5 @@ impl Transpile for BackfStatement {
         })
     }
 }
+
+impl TranspileableStatement for BackfStatement {}

--- a/rosy/src/program/statements/io/closef.rs
+++ b/rosy/src/program/statements/io/closef.rs
@@ -18,12 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `CLOSEF unit;`.
@@ -49,31 +45,6 @@ impl FromRule for ClosefStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected unit expression in CLOSEF"))?;
 
         Ok(Some(ClosefStatement { unit_expr }))
-    }
-}
-impl TranspileableStatement for ClosefStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for ClosefStatement {
@@ -103,3 +74,5 @@ impl Transpile for ClosefStatement {
         })
     }
 }
+
+impl TranspileableStatement for ClosefStatement {}

--- a/rosy/src/program/statements/io/cpusec.rs
+++ b/rosy/src/program/statements/io/cpusec.rs
@@ -18,14 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::core::variable_identifier::VariableIdentifier, statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-    },
+    program::expressions::core::variable_identifier::VariableIdentifier,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope},
 };
 
 /// AST node for `CPUSEC v;`.
@@ -59,31 +53,6 @@ impl FromRule for CpusecStatement {
     }
 }
 
-impl TranspileableStatement for CpusecStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for CpusecStatement {
     fn transpile(
@@ -148,3 +117,5 @@ impl Transpile for CpusecStatement {
         })
     }
 }
+
+impl TranspileableStatement for CpusecStatement {}

--- a/rosy/src/program/statements/io/openf.rs
+++ b/rosy/src/program/statements/io/openf.rs
@@ -22,12 +22,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `OPENF unit filename status;`.
@@ -75,31 +71,6 @@ impl FromRule for OpenfStatement {
         }))
     }
 }
-impl TranspileableStatement for OpenfStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for OpenfStatement {
     fn transpile(
         &self,
@@ -145,3 +116,5 @@ impl Transpile for OpenfStatement {
         })
     }
 }
+
+impl TranspileableStatement for OpenfStatement {}

--- a/rosy/src/program/statements/io/openfb.rs
+++ b/rosy/src/program/statements/io/openfb.rs
@@ -21,12 +21,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `OPENFB unit filename status;`.
@@ -74,31 +70,6 @@ impl FromRule for OpenfbStatement {
         }))
     }
 }
-impl TranspileableStatement for OpenfbStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 impl Transpile for OpenfbStatement {
     fn transpile(
         &self,
@@ -144,3 +115,5 @@ impl Transpile for OpenfbStatement {
         })
     }
 }
+
+impl TranspileableStatement for OpenfbStatement {}

--- a/rosy/src/program/statements/io/os_call.rs
+++ b/rosy/src/program/statements/io/os_call.rs
@@ -18,12 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `OS expr;`.
@@ -48,31 +44,6 @@ impl FromRule for OsCallStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected command expression in OS"))?;
 
         Ok(Some(OsCallStatement { cmd_expr }))
-    }
-}
-impl TranspileableStatement for OsCallStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for OsCallStatement {
@@ -102,3 +73,5 @@ impl Transpile for OsCallStatement {
         })
     }
 }
+
+impl TranspileableStatement for OsCallStatement {}

--- a/rosy/src/program/statements/io/pwtime.rs
+++ b/rosy/src/program/statements/io/pwtime.rs
@@ -18,15 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::core::variable_identifier::VariableIdentifier, statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-        add_context_to_all,
-    },
+    program::expressions::core::variable_identifier::VariableIdentifier,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -55,31 +48,6 @@ impl FromRule for PwtimeStatement {
     }
 }
 
-impl TranspileableStatement for PwtimeStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for PwtimeStatement {
     fn transpile(
@@ -126,3 +94,5 @@ impl Transpile for PwtimeStatement {
         })
     }
 }
+
+impl TranspileableStatement for PwtimeStatement {}

--- a/rosy/src/program/statements/io/read.rs
+++ b/rosy/src/program/statements/io/read.rs
@@ -18,16 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `READ unit variable;` statement.
@@ -63,31 +55,6 @@ impl FromRule for ReadStatement {
         .ok_or_else(|| anyhow::anyhow!("Expected variable identifier for read statement"))?;
 
         Ok(Some(ReadStatement { unit, identifier }))
-    }
-}
-impl TranspileableStatement for ReadStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for ReadStatement {
@@ -173,3 +140,5 @@ impl Transpile for ReadStatement {
         }
     }
 }
+
+impl TranspileableStatement for ReadStatement {}

--- a/rosy/src/program/statements/io/readb.rs
+++ b/rosy/src/program/statements/io/readb.rs
@@ -18,16 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `READB unit variable;`.
@@ -63,31 +55,6 @@ impl FromRule for ReadbStatement {
         .ok_or_else(|| anyhow::anyhow!("Expected variable identifier for READB statement"))?;
 
         Ok(Some(ReadbStatement { unit, identifier }))
-    }
-}
-impl TranspileableStatement for ReadbStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for ReadbStatement {
@@ -156,3 +123,5 @@ impl Transpile for ReadbStatement {
         }
     }
 }
+
+impl TranspileableStatement for ReadbStatement {}

--- a/rosy/src/program/statements/io/readm.rs
+++ b/rosy/src/program/statements/io/readm.rs
@@ -34,16 +34,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-        ValueKind, add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 /// AST node for `READM output_var var_info length dp_array int_array da_params;`.
@@ -126,31 +118,6 @@ impl FromRule for ReadmStatement {
     }
 }
 
-impl TranspileableStatement for ReadmStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for ReadmStatement {
     fn transpile(
@@ -285,3 +252,5 @@ impl Transpile for ReadmStatement {
         })
     }
 }
+
+impl TranspileableStatement for ReadmStatement {}

--- a/rosy/src/program/statements/io/reads.rs
+++ b/rosy/src/program/statements/io/reads.rs
@@ -18,16 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope, add_context_to_all},
 };
 
 /// AST node for `READS unit variable;`.
@@ -67,31 +59,6 @@ impl FromRule for ReadsStatement {
     }
 }
 
-impl TranspileableStatement for ReadsStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for ReadsStatement {
     fn transpile(
@@ -183,3 +150,5 @@ impl Transpile for ReadsStatement {
         })
     }
 }
+
+impl TranspileableStatement for ReadsStatement {}

--- a/rosy/src/program/statements/io/rewf.rs
+++ b/rosy/src/program/statements/io/rewf.rs
@@ -18,12 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `REWF unit;`.
@@ -49,31 +45,6 @@ impl FromRule for RewfStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected unit expression in REWF"))?;
 
         Ok(Some(RewfStatement { unit_expr }))
-    }
-}
-impl TranspileableStatement for RewfStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for RewfStatement {
@@ -103,3 +74,5 @@ impl Transpile for RewfStatement {
         })
     }
 }
+
+impl TranspileableStatement for RewfStatement {}

--- a/rosy/src/program/statements/io/save.rs
+++ b/rosy/src/program/statements/io/save.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, Error, Result, ensure};
 use std::collections::BTreeSet;
 
 use crate::{
-    ast::*, program::expressions::Expr, program::statements::SourceLocation, resolve::*,
+    ast::*, program::expressions::Expr,
     transpile::*,
 };
 
@@ -52,31 +52,6 @@ impl FromRule for SaveStatement {
             .ok_or_else(|| anyhow::anyhow!("Expected filename expression in SAVE"))?;
 
         Ok(Some(SaveStatement { filename_expr }))
-    }
-}
-impl TranspileableStatement for SaveStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for SaveStatement {
@@ -112,3 +87,5 @@ impl Transpile for SaveStatement {
         })
     }
 }
+
+impl TranspileableStatement for SaveStatement {}

--- a/rosy/src/program/statements/io/velget.rs
+++ b/rosy/src/program/statements/io/velget.rs
@@ -22,16 +22,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope, add_context_to_all},
 };
 
 /// AST node for `VELGET vec_expr component_expr output_var;`.
@@ -76,31 +68,6 @@ impl FromRule for VelgetStatement {
             component_expr,
             output_var,
         }))
-    }
-}
-impl TranspileableStatement for VelgetStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for VelgetStatement {
@@ -176,3 +143,5 @@ impl Transpile for VelgetStatement {
         })
     }
 }
+
+impl TranspileableStatement for VelgetStatement {}

--- a/rosy/src/program/statements/io/write.rs
+++ b/rosy/src/program/statements/io/write.rs
@@ -21,17 +21,12 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{
+    program::expressions::{
             Expr, string_convert::string_convert_transpile_helper,
         },
-        statements::SourceLocation,
-    },
+    program::statements::SourceLocation,
     resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for the `WRITE unit expr+;` statement.
@@ -74,50 +69,6 @@ impl FromRule for WriteStatement {
         };
 
         Ok(Some(WriteStatement { unit, exprs }))
-    }
-}
-impl TranspileableStatement for WriteStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-
-    fn wire_inference_edges(
-        &self,
-        resolver: &mut TypeResolver,
-        ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        // Discover function call sites within unit and all write expressions
-        if let Err(e) = resolver.discover_expr_function_calls(&self.unit, ctx) {
-            return InferenceEdgeResult::HasEdges {
-                result: Err(e.context(
-                    "...while discovering function call dependencies in WRITE unit expression",
-                )),
-            };
-        }
-        for expr in &self.exprs {
-            if let Err(e) = resolver.discover_expr_function_calls(expr, ctx) {
-                return InferenceEdgeResult::HasEdges {
-                    result: Err(e.context(
-                        "...while discovering function call dependencies in WRITE statement",
-                    )),
-                };
-            }
-        }
-
-        InferenceEdgeResult::HasEdges { result: Ok(()) }
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for WriteStatement {
@@ -180,5 +131,28 @@ impl Transpile for WriteStatement {
             requested_variables,
             ..Default::default()
         })
+    }
+}
+
+impl TranspileableStatement for WriteStatement {
+    fn wire_inference_edges(
+        &self,
+        resolver: &mut TypeResolver,
+        ctx: &mut ScopeContext,
+        _source_location: SourceLocation,
+    ) -> Option<Result<()>> {
+        if let Err(e) = resolver.discover_expr_function_calls(&self.unit, ctx) {
+            return Some(Err(e.context(
+                "...while discovering function call dependencies in WRITE unit expression",
+            )));
+        }
+        for expr in &self.exprs {
+            if let Err(e) = resolver.discover_expr_function_calls(expr, ctx) {
+                return Some(Err(e.context(
+                    "...while discovering function call dependencies in WRITE statement",
+                )));
+            }
+        }
+        Some(Ok(()))
     }
 }

--- a/rosy/src/program/statements/io/writeb.rs
+++ b/rosy/src/program/statements/io/writeb.rs
@@ -18,12 +18,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `WRITEB unit expr+;`.
@@ -67,31 +63,6 @@ impl FromRule for WritebStatement {
         };
 
         Ok(Some(WritebStatement { unit, exprs }))
-    }
-}
-impl TranspileableStatement for WritebStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
     }
 }
 impl Transpile for WritebStatement {
@@ -141,3 +112,5 @@ impl Transpile for WritebStatement {
         })
     }
 }
+
+impl TranspileableStatement for WritebStatement {}

--- a/rosy/src/program/statements/io/writem.rs
+++ b/rosy/src/program/statements/io/writem.rs
@@ -24,16 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 /// AST node for `WRITEM input var_info length dp_array int_array da_params;`.
@@ -119,31 +111,6 @@ impl FromRule for WritemStatement {
     }
 }
 
-impl TranspileableStatement for WritemStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for WritemStatement {
     fn transpile(
@@ -273,3 +240,5 @@ impl Transpile for WritemStatement {
         })
     }
 }
+
+impl TranspileableStatement for WritemStatement {}

--- a/rosy/src/program/statements/kind.rs
+++ b/rosy/src/program/statements/kind.rs
@@ -1,10 +1,7 @@
 //! Closed statement AST. Replaces `Box<dyn TranspileableStatement>`.
 
 use super::*;
-use crate::transpile::{
-    InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-    TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-};
+use crate::transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement};
 use crate::resolve::{ScopeContext, TypeResolver};
 use crate::program::statements::SourceLocation;
 use anyhow::{Error, Result};
@@ -32,7 +29,7 @@ macro_rules! stmt_kind {
                 resolver: &mut TypeResolver,
                 ctx: &mut ScopeContext,
                 source_location: SourceLocation,
-            ) -> TypeslotDeclarationResult {
+            ) -> Option<Result<()>> {
                 match self {
                     $(Self::$var(s) => s.register_typeslot_declaration(resolver, ctx, source_location),)+
                 }
@@ -42,7 +39,7 @@ macro_rules! stmt_kind {
                 resolver: &mut TypeResolver,
                 ctx: &mut ScopeContext,
                 source_location: SourceLocation,
-            ) -> InferenceEdgeResult {
+            ) -> Option<Result<()>> {
                 match self {
                     $(Self::$var(s) => s.wire_inference_edges(resolver, ctx, source_location),)+
                 }
@@ -51,7 +48,7 @@ macro_rules! stmt_kind {
                 &mut self,
                 resolver: &TypeResolver,
                 current_scope: &[String],
-            ) -> TypeHydrationResult {
+            ) -> Option<Result<()>> {
                 match self {
                     $(Self::$var(s) => s.hydrate_resolved_types(resolver, current_scope),)+
                 }

--- a/rosy/src/program/statements/math/cpolval.rs
+++ b/rosy/src/program/statements/math/cpolval.rs
@@ -36,12 +36,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 /// AST node for `CPOLVAL L P NP A NA R NR;`.
@@ -104,31 +100,6 @@ impl FromRule for CpolvalStatement {
     }
 }
 
-impl TranspileableStatement for CpolvalStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for CpolvalStatement {
     fn transpile(
@@ -224,3 +195,5 @@ impl Transpile for CpolvalStatement {
         })
     }
 }
+
+impl TranspileableStatement for CpolvalStatement {}

--- a/rosy/src/program/statements/math/fit.rs
+++ b/rosy/src/program/statements/math/fit.rs
@@ -31,11 +31,7 @@ use crate::{
         statements::{SourceLocation, Statement},
     },
     resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-        indent,
-    },
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, TranspileableStatement, indent},
 };
 use rosy_lib::RosyType;
 
@@ -162,28 +158,26 @@ impl TranspileableStatement for FitStatement {
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
+    ) -> Option<Result<()>> {
+        None
     }
     fn wire_inference_edges(
         &self,
         resolver: &mut TypeResolver,
         ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::HasEdges {
-            result: resolver.discover_slots(&self.body, &mut ctx.clone()),
-        }
+    ) -> Option<Result<()>> {
+        Some(resolver.discover_slots(&self.body, &mut ctx.clone()),)
     }
     fn hydrate_resolved_types(
         &mut self,
         resolver: &TypeResolver,
         current_scope: &[String],
-    ) -> TypeHydrationResult {
+    ) -> Option<Result<()>> {
         if let Err(e) = resolver.apply_to_ast(&mut self.body, current_scope) {
-            return TypeHydrationResult::Hydrated { result: Err(e) };
+            return Some(Err(e));
         }
-        TypeHydrationResult::Hydrated { result: Ok(()) }
+        Some(Ok(()))
     }
 }
 impl Transpile for FitStatement {

--- a/rosy/src/program/statements/math/intpol.rs
+++ b/rosy/src/program/statements/math/intpol.rs
@@ -27,16 +27,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope, add_context_to_all},
 };
 
 /// AST node for `INTPOL v c;`.
@@ -78,31 +70,6 @@ impl FromRule for IntpolStatement {
     }
 }
 
-impl TranspileableStatement for IntpolStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for IntpolStatement {
     fn transpile(
@@ -164,3 +131,5 @@ impl Transpile for IntpolStatement {
         })
     }
 }
+
+impl TranspileableStatement for IntpolStatement {}

--- a/rosy/src/program/statements/math/ldet.rs
+++ b/rosy/src/program/statements/math/ldet.rs
@@ -24,13 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 /// AST node for `LDET matrix n alloc_dim result ;`.
@@ -83,31 +78,6 @@ impl FromRule for LdetStatement {
     }
 }
 
-impl TranspileableStatement for LdetStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for LdetStatement {
     fn transpile(
@@ -164,3 +134,5 @@ impl Transpile for LdetStatement {
         })
     }
 }
+
+impl TranspileableStatement for LdetStatement {}

--- a/rosy/src/program/statements/math/lev.rs
+++ b/rosy/src/program/statements/math/lev.rs
@@ -25,13 +25,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -97,31 +92,6 @@ impl FromRule for LevStatement {
     }
 }
 
-impl TranspileableStatement for LevStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for LevStatement {
     fn transpile(
@@ -202,3 +172,5 @@ impl Transpile for LevStatement {
         })
     }
 }
+
+impl TranspileableStatement for LevStatement {}

--- a/rosy/src/program/statements/math/linv.rs
+++ b/rosy/src/program/statements/math/linv.rs
@@ -24,13 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 /// AST node for `LINV matrix inverse n alloc_dim error_flag;`.
@@ -92,31 +87,6 @@ impl FromRule for LinvStatement {
     }
 }
 
-impl TranspileableStatement for LinvStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for LinvStatement {
     fn transpile(
@@ -191,3 +161,5 @@ impl Transpile for LinvStatement {
         })
     }
 }
+
+impl TranspileableStatement for LinvStatement {}

--- a/rosy/src/program/statements/math/lsline.rs
+++ b/rosy/src/program/statements/math/lsline.rs
@@ -24,16 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 /// AST node for `LSLINE x y n a b;`.
@@ -95,31 +87,6 @@ impl FromRule for LslineStatement {
     }
 }
 
-impl TranspileableStatement for LslineStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for LslineStatement {
     fn transpile(
@@ -197,3 +164,5 @@ impl Transpile for LslineStatement {
         })
     }
 }
+
+impl TranspileableStatement for LslineStatement {}

--- a/rosy/src/program/statements/math/mblock.rs
+++ b/rosy/src/program/statements/math/mblock.rs
@@ -24,13 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -95,31 +90,6 @@ impl FromRule for MblockStatement {
     }
 }
 
-impl TranspileableStatement for MblockStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for MblockStatement {
     fn transpile(
@@ -189,3 +159,5 @@ impl Transpile for MblockStatement {
         })
     }
 }
+
+impl TranspileableStatement for MblockStatement {}

--- a/rosy/src/program/statements/math/polval.rs
+++ b/rosy/src/program/statements/math/polval.rs
@@ -28,13 +28,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{expressions::Expr, statements::SourceLocation},
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableExpr, TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult,
-        add_context_to_all,
-    },
+    program::expressions::Expr,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableExpr, TranspileableStatement, add_context_to_all},
 };
 use rosy_lib::RosyBaseType;
 
@@ -98,31 +93,6 @@ impl FromRule for PolvalStatement {
     }
 }
 
-impl TranspileableStatement for PolvalStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for PolvalStatement {
     fn transpile(
@@ -232,3 +202,5 @@ impl Transpile for PolvalStatement {
         })
     }
 }
+
+impl TranspileableStatement for PolvalStatement {}

--- a/rosy/src/program/statements/math/rkco.rs
+++ b/rosy/src/program/statements/math/rkco.rs
@@ -26,15 +26,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::core::variable_identifier::VariableIdentifier, statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, ValueKind,
-        add_context_to_all,
-    },
+    program::expressions::core::variable_identifier::VariableIdentifier,
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, ValueKind, add_context_to_all},
 };
 
 /// AST node for `RKCO c b e a1 a2;`.
@@ -92,31 +85,6 @@ impl FromRule for RkcoStatement {
     }
 }
 
-impl TranspileableStatement for RkcoStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for RkcoStatement {
     fn transpile(
@@ -190,3 +158,5 @@ impl Transpile for RkcoStatement {
         })
     }
 }
+
+impl TranspileableStatement for RkcoStatement {}

--- a/rosy/src/program/statements/math/vedot.rs
+++ b/rosy/src/program/statements/math/vedot.rs
@@ -22,16 +22,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -78,31 +70,6 @@ impl FromRule for VedotStatement {
     }
 }
 
-impl TranspileableStatement for VedotStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for VedotStatement {
     fn transpile(
@@ -163,3 +130,5 @@ impl Transpile for VedotStatement {
         })
     }
 }
+
+impl TranspileableStatement for VedotStatement {}

--- a/rosy/src/program/statements/math/veunit.rs
+++ b/rosy/src/program/statements/math/veunit.rs
@@ -21,16 +21,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, VariableScope,
-        add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, VariableScope, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -68,31 +60,6 @@ impl FromRule for VeunitStatement {
     }
 }
 
-impl TranspileableStatement for VeunitStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for VeunitStatement {
     fn transpile(
@@ -151,3 +118,5 @@ impl Transpile for VeunitStatement {
         })
     }
 }
+
+impl TranspileableStatement for VeunitStatement {}

--- a/rosy/src/program/statements/math/vezero.rs
+++ b/rosy/src/program/statements/math/vezero.rs
@@ -24,15 +24,8 @@ use std::collections::BTreeSet;
 
 use crate::{
     ast::*,
-    program::{
-        expressions::{Expr, core::variable_identifier::VariableIdentifier},
-        statements::SourceLocation,
-    },
-    resolve::{ScopeContext, TypeResolver},
-    transpile::{
-        InferenceEdgeResult, TranspilationInputContext, TranspilationOutput, Transpile,
-        TranspileableStatement, TypeHydrationResult, TypeslotDeclarationResult, add_context_to_all,
-    },
+    program::expressions::{Expr, core::variable_identifier::VariableIdentifier},
+    transpile::{TranspilationInputContext, TranspilationOutput, Transpile, TranspileableStatement, add_context_to_all},
 };
 
 #[derive(Debug)]
@@ -79,31 +72,6 @@ impl FromRule for VezeroStatement {
     }
 }
 
-impl TranspileableStatement for VezeroStatement {
-    fn register_typeslot_declaration(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult {
-        TypeslotDeclarationResult::NotAVarFuncOrProcedureDecl
-    }
-    fn wire_inference_edges(
-        &self,
-        _resolver: &mut TypeResolver,
-        _ctx: &mut ScopeContext,
-        _source_location: SourceLocation,
-    ) -> InferenceEdgeResult {
-        InferenceEdgeResult::NoEdges
-    }
-    fn hydrate_resolved_types(
-        &mut self,
-        _resolver: &TypeResolver,
-        _current_scope: &[String],
-    ) -> TypeHydrationResult {
-        TypeHydrationResult::NothingToHydrate
-    }
-}
 
 impl Transpile for VezeroStatement {
     fn transpile(
@@ -154,3 +122,5 @@ impl Transpile for VezeroStatement {
         })
     }
 }
+
+impl TranspileableStatement for VezeroStatement {}

--- a/rosy/src/resolve.rs
+++ b/rosy/src/resolve.rs
@@ -16,10 +16,7 @@ use crate::errors::RosyError;
 use crate::program::Program;
 use crate::program::expressions::*;
 use crate::program::statements::*;
-use crate::transpile::{
-    ExprFunctionCallResult, InferenceEdgeResult, TranspileableExpr, TranspileableStatement,
-    TypeHydrationResult, TypeslotDeclarationResult,
-};
+use crate::transpile::{TranspileableExpr, TranspileableStatement};
 use anyhow::{Result, anyhow};
 use rosy_lib::RosyType;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -285,14 +282,9 @@ impl TypeResolver {
         stmt: &Statement,
         ctx: &mut ScopeContext,
     ) -> Result<()> {
-        let TypeslotDeclarationResult::VarFuncOrProcedureDecl { result } = stmt
-            .inner
+        stmt.inner
             .register_typeslot_declaration(self, ctx, stmt.source_location.clone())
-        else {
-            return Ok(()); // not a declaration, skip
-        };
-
-        result
+            .unwrap_or(Ok(()))
     }
 
     /// Walk statements looking for assignments and call sites to establish dependencies.
@@ -301,23 +293,17 @@ impl TypeResolver {
         stmt: &Statement,
         ctx: &mut ScopeContext,
     ) -> Result<()> {
-        let InferenceEdgeResult::HasEdges { result } =
-            stmt.inner
-                .wire_inference_edges(self, ctx, stmt.source_location.clone())
-        else {
-            return Ok(());
-        };
-
-        result
+        stmt.inner
+            .wire_inference_edges(self, ctx, stmt.source_location.clone())
+            .unwrap_or(Ok(()))
     }
 
     /// Recursively walk an expression tree looking for function calls.
     /// For each one found, wire up call-site argument dependencies.
     pub fn discover_expr_function_calls(&mut self, expr: &Expr, ctx: &ScopeContext) -> Result<()> {
-        match expr.inner.discover_expr_function_calls(self, ctx) {
-            ExprFunctionCallResult::HasFunctionCalls { result } => result,
-            ExprFunctionCallResult::NoFunctionCalls => Ok(()),
-        }
+        expr.inner
+            .discover_expr_function_calls(self, ctx)
+            .unwrap_or(Ok(()))
     }
 
     /// For a call site like `F(X, Y)`, if `F` has untyped parameters, add
@@ -776,12 +762,9 @@ impl TypeResolver {
         current_scope: &[String],
     ) -> Result<()> {
         for stmt in statements.iter_mut() {
-            let TypeHydrationResult::Hydrated { result } =
-                stmt.inner.hydrate_resolved_types(self, current_scope)
-            else {
-                continue;
-            };
-            result?;
+            if let Some(result) = stmt.inner.hydrate_resolved_types(self, current_scope) {
+                result?;
+            }
         }
 
         Ok(())

--- a/rosy/src/transpile.rs
+++ b/rosy/src/transpile.rs
@@ -29,52 +29,40 @@ use anyhow::{Error, Result};
 use rosy_lib::RosyType;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-pub enum TypeslotDeclarationResult {
-    VarFuncOrProcedureDecl { result: Result<()> },
-    NotAVarFuncOrProcedureDecl,
-}
-
-pub enum InferenceEdgeResult {
-    HasEdges { result: Result<()> },
-    NoEdges,
-}
-
-pub enum TypeHydrationResult {
-    Hydrated { result: Result<()> },
-    NothingToHydrate,
-}
-
-pub enum ExprFunctionCallResult {
-    HasFunctionCalls { result: Result<()> },
-    NoFunctionCalls,
-}
-
-pub trait TranspileableStatement: Transpile + Send + Sync {
+pub trait TranspileableStatement: Transpile {
     fn register_typeslot_declaration(
         &self,
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> TypeslotDeclarationResult;
+    ) -> Option<Result<()>> {
+        None
+    }
     fn wire_inference_edges(
         &self,
         _resolver: &mut TypeResolver,
         _ctx: &mut ScopeContext,
         _source_location: SourceLocation,
-    ) -> InferenceEdgeResult;
+    ) -> Option<Result<()>> {
+        None
+    }
     fn hydrate_resolved_types(
         &mut self,
         _resolver: &TypeResolver,
         _current_scope: &[String],
-    ) -> TypeHydrationResult;
+    ) -> Option<Result<()>> {
+        None
+    }
 }
-pub trait TranspileableExpr: Transpile + Send + Sync {
+pub trait TranspileableExpr: Transpile {
     fn type_of(&self, context: &TranspilationInputContext) -> Result<RosyType>;
     fn discover_expr_function_calls(
         &self,
-        resolver: &mut TypeResolver,
-        ctx: &ScopeContext,
-    ) -> ExprFunctionCallResult;
+        _resolver: &mut TypeResolver,
+        _ctx: &ScopeContext,
+    ) -> Option<Result<()>> {
+        None
+    }
     fn build_expr_recipe(
         &self,
         resolver: &TypeResolver,

--- a/rosy/src/update_check.rs
+++ b/rosy/src/update_check.rs
@@ -9,12 +9,10 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(serde::Deserialize)]
 struct GithubRelease {
-    tag_name: String,
-}
+    tag_name: String}
 
 pub struct UpdateHandle {
-    rx: mpsc::Receiver<Option<String>>,
-}
+    rx: mpsc::Receiver<Option<String>>}
 
 /// Spawn a background thread that checks for a newer release on GitHub.
 /// Returns a handle you can later call `.check()` on to print a warning if needed.


### PR DESCRIPTION
## Summary

Follow-up to the /ponytail-audit pass (Run/Build clap flatten left alone). Same behavior, less code.

- Default `TranspileableStatement` / `discover_expr_function_calls` so most statements are `impl TranspileableStatement for Foo {}`
- Collapse the four `HasEdges { result }` enums to `Option<Result<()>>`; drop leftover `Send + Sync`
- Delete unused `IntrinsicTypeRule` / `*_REGISTRY` tables; `get_return_type` is a `match`
- Shrink `TypeRule` to `lhs` / `rhs` / `result`
- Drop crate-wide `allow(dead_code)` / `unused_imports` on `rosy_lib`
- Compact `RosyType::{RE,ST,…}` constructors; delete `core/reran.rs`; emit `RERAN` via `core::rng`
- Restore call-site inference on procedure/function calls (and VELSET/WRITE discover)

**v1.7.1**

## Test plan

- [x] `cargo test --workspace --lib --bins`
- [x] `cargo run --bin rosy -- test` — 167/167 construct fixtures